### PR TITLE
feat: normalized supplement types for decode output convention

### DIFF
--- a/src/gainmap.rs
+++ b/src/gainmap.rs
@@ -287,6 +287,75 @@ impl GainMapPresence {
 }
 
 // =========================================================================
+// Gain map source (raw, pre-decode)
+// =========================================================================
+
+/// Raw gain map data extracted from container — not yet pixel-decoded.
+///
+/// Produced by codecs when gain map extraction is opted in. The caller
+/// decodes the raw bitstream through the normal codec path (with limits,
+/// cancellation, streaming). This avoids hidden nested decodes inside
+/// the primary decoder.
+///
+/// # Recursion safety
+///
+/// The `depth` field tracks nesting level. Callers MUST reject
+/// `depth >= MAX_DEPTH` (typically 1) to prevent infinite recursion —
+/// a JXL gain map is a bare JXL codestream, and a JPEG UltraHDR gain
+/// map is a full JPEG that could itself contain MPF references.
+///
+/// # Ownership
+///
+/// The `data` field is owned (`Vec<u8>`) for storage in
+/// [`DecodeOutput`](crate::decode::DecodeOutput) extensions.
+/// Codecs that can provide zero-copy access to the gain map bitstream
+/// should offer a codec-specific API returning `&[u8]` for callers
+/// that decode immediately without storing.
+///
+/// # Codec behavior
+///
+/// | Container | `format` | `data` contents |
+/// |-----------|----------|-----------------|
+/// | AVIF | `Avif` | Raw AV1 bitstream (OBUs) |
+/// | JXL | `Jxl` | Bare JXL codestream (no container boxes) |
+/// | JPEG (UltraHDR) | `Jpeg` | Complete JPEG file (MPF secondary image) |
+/// | HEIC | — | Not produced — HEIC parser decodes gain map internally, use [`DecodedGainMap`] |
+#[derive(Clone, Debug)]
+pub struct GainMapSource {
+    /// Raw encoded bitstream of the gain map image.
+    pub data: alloc::vec::Vec<u8>,
+    /// Codec format needed to decode `data`.
+    pub format: crate::ImageFormat,
+    /// ISO 21496-1 gain map metadata (parsed from container).
+    pub metadata: GainMapInfo,
+    /// Nesting depth. 0 = gain map of a primary image.
+    /// Callers should reject `depth >= 1` to prevent recursion.
+    pub depth: u8,
+}
+
+// Decoded gain map (post-decode)
+// =========================================================================
+
+/// Decoded gain map image — cross-codec normalized type.
+///
+/// Produced either by:
+/// - Decoding a [`GainMapSource`] through the normal codec path
+/// - Codecs that decode the gain map internally (HEIC)
+///
+/// Stored in [`DecodeOutput`](crate::decode::DecodeOutput) extensions
+/// via `output.with_extras(decoded_gain_map)`.
+///
+/// Gain map decode is opt-in — this is only present when the caller
+/// explicitly requested gain map extraction.
+#[derive(Debug)]
+pub struct DecodedGainMap {
+    /// Gain map image pixels.
+    pub pixels: zenpixels::PixelBuffer,
+    /// ISO 21496-1 gain map metadata.
+    pub metadata: GainMapInfo,
+}
+
+// =========================================================================
 // ISO 21496-1 fractions
 // =========================================================================
 


### PR DESCRIPTION
## Summary

- Add `GainMapSource` — raw gain map bytes + format + metadata + recursion depth counter for safe caller-driven nested decode
- Add `DecodedGainMap` — decoded gain map pixels + ISO 21496-1 metadata (post-decode normalized type)
- Add `DecodedDepthMap` — decoded depth map pixels (post-decode normalized type)
- All three exported from crate root

## Design

**Two-stage gain map access:**
- `GainMapSource` (pre-decode): codec extracts raw bitstream from container without pixel-decoding. Caller creates a bounded decoder with recursion protection (`depth >= 1` rejected).
- `DecodedGainMap` (post-decode): caller decodes `GainMapSource` through normal codec path, or codec produces this directly (HEIC — parser handles HEVC decode internally).

**Recursion safety:** `GainMapSource.depth: u8` tracks nesting level. JXL jhgm is a bare JXL codestream and JPEG UltraHDR is a full JPEG — both can theoretically recurse. The depth counter caps this at 1 level.

**Ownership:** `GainMapSource.data` is `Vec<u8>` (owned) for storage in `Extensions` type-map which requires `'static`. Codecs offering zero-copy access should provide codec-specific `&[u8]` APIs for immediate-decode callers.

**Convention documented** in `docs/spec.md`: discovery via `ImageInfo.supplements`, opt-in decode, access via `extras::<T>()`.

## Codec behavior table

| Container | `format` | `data` contents | Notes |
|-----------|----------|-----------------|-------|
| AVIF | `Avif` | Raw AV1 bitstream (OBUs) | No recursion risk |
| JXL | `Jxl` | Bare JXL codestream (no container boxes) | Recursion possible |
| JPEG (UltraHDR) | `Jpeg` | Complete JPEG file (MPF secondary) | Recursion possible |
| HEIC | — | Not produced — use `DecodedGainMap` directly | Parser handles HEVC internally |

## Test plan
- [x] `cargo test` passes
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [ ] Downstream codec migration (separate PRs per codec)