### PR TITLE
fix: panic removal, ISOBMFF box_size handling, silent no-op docs

### DIFF
--- a/src/format/builtins.rs
+++ b/src/format/builtins.rs
@@ -13,9 +13,28 @@ fn has_ftyp(data: &[u8]) -> bool {
 }
 
 fn scan_compat_brands(data: &[u8], target: &[&[u8; 4]]) -> bool {
-    let box_size = u32::from_be_bytes([data[0], data[1], data[2], data[3]]) as usize;
-    let end = box_size.min(data.len());
-    let mut offset = 16;
+    let box_size_u32 = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
+    let end = match box_size_u32 {
+        // box_size == 0 means the box extends to the end of the data
+        0 => data.len(),
+        // box_size == 1 means the real size is a 64-bit value at offset 8
+        1 => {
+            if data.len() < 16 {
+                return false;
+            }
+            let extended = u64::from_be_bytes([
+                data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15],
+            ]);
+            // Clamp to data length (we only scan what we have)
+            (extended as usize).min(data.len())
+        }
+        size => (size as usize).min(data.len()),
+    };
+    // For box_size == 1, compatible brands start after the 16-byte header
+    // (8 bytes extended size overlaps the major_brand/minor_version area,
+    // so brands start at offset 24). For normal boxes, brands start at 16.
+    let brands_start = if box_size_u32 == 1 { 24 } else { 16 };
+    let mut offset = brands_start;
     while offset + 4 <= end {
         let compat = &data[offset..offset + 4];
         if target.iter().any(|b| compat[..4] == b[..]) {

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -1145,4 +1145,110 @@ mod tests {
         // GIF not in registry
         assert_eq!(reg.detect(b"GIF89a\x00\x00"), None);
     }
+
+    // --- scan_compat_brands regression tests ---
+
+    /// Helper: build a minimal ftyp box with the given box_size, major brand,
+    /// and list of compatible brands.
+    fn build_ftyp(box_size: u32, major: &[u8; 4], compat: &[&[u8; 4]]) -> Vec<u8> {
+        // Normal ftyp: [4 box_size][4 "ftyp"][4 major][4 minor][compat brands...]
+        let mut data = Vec::new();
+        data.extend_from_slice(&box_size.to_be_bytes());
+        data.extend_from_slice(b"ftyp");
+        data.extend_from_slice(major);
+        data.extend_from_slice(&[0u8; 4]); // minor_version
+        for brand in compat {
+            data.extend_from_slice(*brand);
+        }
+        data
+    }
+
+    #[test]
+    fn scan_compat_brands_normal_box() {
+        // Normal ftyp: box_size includes all compat brands
+        let data = build_ftyp(24, b"mif1", &[b"avif"]);
+        assert_eq!(reg().detect(&data), Some(ImageFormat::Avif));
+    }
+
+    #[test]
+    fn scan_compat_brands_box_size_zero() {
+        // box_size=0 means "extends to end of data" per ISOBMFF spec.
+        // scan_compat_brands should scan all remaining bytes.
+        let mut data = build_ftyp(0, b"mif1", &[b"avif"]);
+        data.extend_from_slice(&[0u8; 8]); // extra padding
+        assert_eq!(reg().detect(&data), Some(ImageFormat::Avif));
+    }
+
+    #[test]
+    fn scan_compat_brands_box_size_zero_no_brands() {
+        // box_size=0 but no compat brands present
+        let data = build_ftyp(0, b"mif1", &[]);
+        assert_eq!(reg().detect(&data), None);
+    }
+
+    #[test]
+    fn scan_compat_brands_box_size_one_extended() {
+        // box_size=1 → 64-bit extended size at offset 8.
+        // ISOBMFF layout: [4:size=1][4:type][8:ext_size][4:major][4:minor][brands...]
+        //
+        // Note: detect_avif/detect_heic always read data[8..12] as the major
+        // brand. For box_size=1, data[8..15] is the extended size, so the
+        // "major brand" read is actually the high bytes of the extended size.
+        // We encode the extended size so its high bytes spell "mif1" to trigger
+        // the compat brand scan path. This tests scan_compat_brands correctly
+        // reads brands starting at offset 24.
+        let mut data = Vec::new();
+        data.extend_from_slice(&1u32.to_be_bytes()); // box_size = 1
+        data.extend_from_slice(b"ftyp");
+        // Extended size: high 4 bytes = "mif1" (read as major by detect_*),
+        // low 4 bytes = actual size
+        let mut ext = [0u8; 8];
+        ext[0..4].copy_from_slice(b"mif1");
+        ext[4..8].copy_from_slice(&36u32.to_be_bytes());
+        data.extend_from_slice(&ext);
+        data.extend_from_slice(b"mif1"); // actual major brand (offset 16, ignored)
+        data.extend_from_slice(&[0u8; 4]); // minor version (offset 20)
+        data.extend_from_slice(b"avif"); // compat brand (offset 24)
+        data.resize(36, 0); // pad to declared extended size
+        assert_eq!(reg().detect(&data), Some(ImageFormat::Avif));
+    }
+
+    #[test]
+    fn scan_compat_brands_extended_too_short_for_header() {
+        // box_size=1 but only 12 bytes of data — too short for 64-bit extended
+        // size field. scan_compat_brands should return false (data.len() < 16).
+        let data = [
+            0x00, 0x00, 0x00, 0x01, b'f', b't', b'y', b'p', b'm', b'i', b'f', b'1',
+        ];
+        assert_eq!(reg().detect(&data), None);
+    }
+
+    #[test]
+    fn scan_compat_brands_box_smaller_than_16() {
+        // box_size=8 means no room for compat brands — brands at offset 16+
+        // are outside the declared box and must not be scanned
+        let mut data = vec![0u8; 20];
+        data[0..4].copy_from_slice(&8u32.to_be_bytes());
+        data[4..8].copy_from_slice(b"ftyp");
+        data[8..12].copy_from_slice(b"mif1");
+        data[12..16].copy_from_slice(&[0u8; 4]);
+        data[16..20].copy_from_slice(b"avif"); // outside declared box
+        assert_eq!(reg().detect(&data), None);
+    }
+
+    #[test]
+    fn scan_compat_brands_multiple_brands_last_match() {
+        // Target brand is the last in a list of 4
+        let data = build_ftyp(36, b"mif1", &[b"isom", b"iso2", b"mp41", b"avif"]);
+        assert_eq!(reg().detect(&data), Some(ImageFormat::Avif));
+    }
+
+    #[test]
+    fn scan_compat_brands_truncated_box() {
+        // box_size says 100 but data is only 24 bytes — scanner should clamp
+        // to actual data length and find the brand within available data
+        let data = build_ftyp(100, b"mif1", &[b"avif"]);
+        assert_eq!(data.len(), 20); // only 20 bytes actually built
+        assert_eq!(reg().detect(&data), Some(ImageFormat::Avif));
+    }
 }

--- a/src/traits/decoding.rs
+++ b/src/traits/decoding.rs
@@ -114,8 +114,13 @@ pub trait DecodeJob<'a>: Sized {
 
     /// Set decode security policy (controls metadata extraction, parsing strictness, etc.).
     ///
-    /// Default no-op. Codecs that support policy check the flags in
-    /// [`DecodePolicy`](crate::decode::DecodePolicy) to decide what to extract and accept.
+    /// # Note
+    ///
+    /// The default implementation is a no-op that returns `self` unchanged.
+    /// Not all codecs implement policy support. Check the codec's documentation
+    /// or [`DecodeCapabilities`](crate::DecodeCapabilities) to determine whether
+    /// the codec honors policy settings. Calling this on a codec that does not
+    /// implement it will silently have no effect.
     fn with_policy(self, _policy: crate::DecodePolicy) -> Self {
         self
     }

--- a/src/traits/dyn_decoding.rs
+++ b/src/traits/dyn_decoding.rs
@@ -272,16 +272,20 @@ pub trait DynDecodeJob<'a> {
 struct DecodeJobShim<J>(Option<J>);
 
 impl<J> DecodeJobShim<J> {
-    fn take(&mut self) -> J {
-        self.0.take().expect("job already consumed")
+    fn take(&mut self) -> Result<J, BoxedError> {
+        self.0
+            .take()
+            .ok_or_else(|| "DecodeJobShim: job already consumed (double take)".into())
     }
 
     fn put(&mut self, job: J) {
         self.0 = Some(job);
     }
 
-    fn as_ref(&self) -> &J {
-        self.0.as_ref().expect("job already consumed")
+    fn as_ref(&self) -> Result<&J, BoxedError> {
+        self.0
+            .as_ref()
+            .ok_or_else(|| "DecodeJobShim: job already consumed (double take)".into())
     }
 }
 
@@ -292,50 +296,57 @@ where
     J::AnimationFrameDec: Send,
 {
     fn set_stop(&mut self, stop: StopToken) {
-        let job = self.take();
-        self.put(job.with_stop(stop));
+        if let Ok(job) = self.take() {
+            self.put(job.with_stop(stop));
+        }
     }
 
     fn set_limits(&mut self, limits: ResourceLimits) {
-        let job = self.take();
-        self.put(job.with_limits(limits));
+        if let Ok(job) = self.take() {
+            self.put(job.with_limits(limits));
+        }
     }
 
     fn set_policy(&mut self, policy: crate::DecodePolicy) {
-        let job = self.take();
-        self.put(job.with_policy(policy));
+        if let Ok(job) = self.take() {
+            self.put(job.with_policy(policy));
+        }
     }
 
     fn probe(&self, data: &[u8]) -> Result<ImageInfo, BoxedError> {
-        self.as_ref()
+        self.as_ref()?
             .probe(data)
             .map_err(|e| Box::new(e) as BoxedError)
     }
 
     fn probe_full(&self, data: &[u8]) -> Result<ImageInfo, BoxedError> {
-        self.as_ref()
+        self.as_ref()?
             .probe_full(data)
             .map_err(|e| Box::new(e) as BoxedError)
     }
 
     fn set_crop_hint(&mut self, x: u32, y: u32, width: u32, height: u32) {
-        let job = self.take();
-        self.put(job.with_crop_hint(x, y, width, height));
+        if let Ok(job) = self.take() {
+            self.put(job.with_crop_hint(x, y, width, height));
+        }
     }
 
     fn set_orientation(&mut self, hint: OrientationHint) {
-        let job = self.take();
-        self.put(job.with_orientation(hint));
+        if let Ok(job) = self.take() {
+            self.put(job.with_orientation(hint));
+        }
     }
 
     fn set_start_frame_index(&mut self, index: u32) {
-        let job = self.take();
-        self.put(job.with_start_frame_index(index));
+        if let Ok(job) = self.take() {
+            self.put(job.with_start_frame_index(index));
+        }
     }
 
     fn set_extract_gain_map(&mut self, extract: bool) {
-        let job = self.take();
-        self.put(job.with_extract_gain_map(extract));
+        if let Ok(job) = self.take() {
+            self.put(job.with_extract_gain_map(extract));
+        }
     }
 
     fn extensions(&self) -> Option<&dyn Any> {
@@ -347,7 +358,7 @@ where
     }
 
     fn output_info(&self, data: &[u8]) -> Result<OutputInfo, BoxedError> {
-        self.as_ref()
+        self.as_ref()?
             .output_info(data)
             .map_err(|e| Box::new(e) as BoxedError)
     }
@@ -357,7 +368,7 @@ where
         data: Cow<'a, [u8]>,
         preferred: &[PixelDescriptor],
     ) -> Result<Box<dyn DynDecoder + 'a>, BoxedError> {
-        let job = self.take();
+        let job = self.take()?;
         let dec = job
             .decoder(data, preferred)
             .map_err(|e| Box::new(e) as BoxedError)?;
@@ -370,7 +381,7 @@ where
         sink: &mut dyn crate::DecodeRowSink,
         preferred: &[PixelDescriptor],
     ) -> Result<OutputInfo, BoxedError> {
-        let job = self.take();
+        let job = self.take()?;
         job.push_decoder(data, sink, preferred)
             .map_err(|e| Box::new(e) as BoxedError)
     }
@@ -380,7 +391,7 @@ where
         data: Cow<'a, [u8]>,
         preferred: &[PixelDescriptor],
     ) -> Result<Box<dyn DynStreamingDecoder + 'a>, BoxedError> {
-        let job = self.take();
+        let job = self.take()?;
         let dec = job
             .streaming_decoder(data, preferred)
             .map_err(|e| Box::new(e) as BoxedError)?;
@@ -392,7 +403,7 @@ where
         data: Cow<'a, [u8]>,
         preferred: &[PixelDescriptor],
     ) -> Result<Box<dyn DynAnimationFrameDecoder>, BoxedError> {
-        let job = self.take();
+        let job = self.take()?;
         let dec = job
             .animation_frame_decoder(data, preferred)
             .map_err(|e| Box::new(e) as BoxedError)?;

--- a/src/traits/dyn_encoding.rs
+++ b/src/traits/dyn_encoding.rs
@@ -255,8 +255,10 @@ pub trait DynEncodeJob {
 struct EncodeJobShim<J>(Option<J>);
 
 impl<J> EncodeJobShim<J> {
-    fn take(&mut self) -> J {
-        self.0.take().expect("job already consumed")
+    fn take(&mut self) -> Result<J, BoxedError> {
+        self.0
+            .take()
+            .ok_or_else(|| "EncodeJobShim: job already consumed (double take)".into())
     }
 
     fn put(&mut self, job: J) {
@@ -271,33 +273,39 @@ where
     J::AnimationFrameEnc: AnimationFrameEncoder,
 {
     fn set_stop(&mut self, stop: StopToken) {
-        let job = self.take();
-        self.put(job.with_stop(stop));
+        if let Ok(job) = self.take() {
+            self.put(job.with_stop(stop));
+        }
     }
 
     fn set_limits(&mut self, limits: ResourceLimits) {
-        let job = self.take();
-        self.put(job.with_limits(limits));
+        if let Ok(job) = self.take() {
+            self.put(job.with_limits(limits));
+        }
     }
 
     fn set_policy(&mut self, policy: crate::EncodePolicy) {
-        let job = self.take();
-        self.put(job.with_policy(policy));
+        if let Ok(job) = self.take() {
+            self.put(job.with_policy(policy));
+        }
     }
 
     fn set_metadata(&mut self, meta: Metadata) {
-        let job = self.take();
-        self.put(job.with_metadata(meta));
+        if let Ok(job) = self.take() {
+            self.put(job.with_metadata(meta));
+        }
     }
 
     fn set_canvas_size(&mut self, width: u32, height: u32) {
-        let job = self.take();
-        self.put(job.with_canvas_size(width, height));
+        if let Ok(job) = self.take() {
+            self.put(job.with_canvas_size(width, height));
+        }
     }
 
     fn set_loop_count(&mut self, count: Option<u32>) {
-        let job = self.take();
-        self.put(job.with_loop_count(count));
+        if let Ok(job) = self.take() {
+            self.put(job.with_loop_count(count));
+        }
     }
 
     fn extensions(&self) -> Option<&dyn Any> {
@@ -309,7 +317,7 @@ where
     }
 
     fn into_encoder(mut self: Box<Self>) -> Result<Box<dyn DynEncoder>, BoxedError> {
-        let job = self.take();
+        let job = self.take()?;
         let enc = job.encoder().map_err(|e| Box::new(e) as BoxedError)?;
         Ok(Box::new(EncoderShim(enc)))
     }
@@ -317,7 +325,7 @@ where
     fn into_animation_frame_encoder(
         mut self: Box<Self>,
     ) -> Result<Box<dyn DynAnimationFrameEncoder>, BoxedError> {
-        let job = self.take();
+        let job = self.take()?;
         let enc = job
             .animation_frame_encoder()
             .map_err(|e| Box::new(e) as BoxedError)?;

--- a/src/traits/encoder.rs
+++ b/src/traits/encoder.rs
@@ -91,10 +91,8 @@ pub trait Encoder: Sized {
             PixelDescriptor::RGBA8_SRGB
         };
         let stride_bytes = stride_pixels as usize * 4;
-        // PixelSlice::new only fails on dimension/stride/length mismatch,
-        // which would be a caller bug. Panic is appropriate here.
         let pixels = PixelSlice::new(data, width, height, stride_bytes, descriptor)
-            .expect("encode_srgba8: invalid dimensions or data length for RGBA8");
+            .map_err(|_| Self::reject(crate::UnsupportedOperation::PixelFormat))?;
         self.encode(pixels)
     }
 

--- a/src/traits/encoder.rs
+++ b/src/traits/encoder.rs
@@ -91,8 +91,13 @@ pub trait Encoder: Sized {
             PixelDescriptor::RGBA8_SRGB
         };
         let stride_bytes = stride_pixels as usize * 4;
-        let pixels = PixelSlice::new(data, width, height, stride_bytes, descriptor)
-            .map_err(|_| Self::reject(crate::UnsupportedOperation::PixelFormat))?;
+        // PixelSlice::new only fails on dimension/stride/length mismatch,
+        // which is a caller bug (not untrusted input — encoders receive
+        // validated data). Panic is appropriate; UnsupportedOperation::PixelFormat
+        // would mask the real issue and mislead callers.
+        let pixels = PixelSlice::new(data, width, height, stride_bytes, descriptor).expect(
+            "encode_srgba8: data.len() does not match width * height * 4 (stride-adjusted)",
+        );
         self.encode(pixels)
     }
 

--- a/src/traits/encoding.rs
+++ b/src/traits/encoding.rs
@@ -50,13 +50,17 @@ pub trait EncoderConfig: Clone + Send + Sync {
         &EncodeCapabilities::EMPTY
     }
 
-    /// Set encoding quality on a calibrated 0.0–100.0 scale.
+    /// Set encoding quality on a calibrated 0.0--100.0 scale.
     ///
     /// "Generic" because this is the codec-agnostic quality knob. Individual
     /// codecs may also have format-specific quality methods on their config types.
     ///
-    /// Default no-op. Check [`generic_quality()`](EncoderConfig::generic_quality)
-    /// for the current value.
+    /// # Note
+    ///
+    /// The default implementation is a no-op. Not all codecs support quality
+    /// tuning. Use [`generic_quality()`](EncoderConfig::generic_quality) after
+    /// calling this to verify the codec accepted the value -- it returns `None`
+    /// if the codec does not support quality settings.
     fn with_generic_quality(self, _quality: f32) -> Self {
         self
     }
@@ -67,21 +71,39 @@ pub trait EncoderConfig: Clone + Send + Sync {
     /// codecs may also have format-specific effort/speed methods.
     ///
     /// Each codec maps this to its internal effort/speed scale.
-    /// Default no-op.
+    ///
+    /// # Note
+    ///
+    /// The default implementation is a no-op. Not all codecs support effort
+    /// tuning. Use [`generic_effort()`](EncoderConfig::generic_effort) after
+    /// calling this to verify the codec accepted the value -- it returns `None`
+    /// if the codec does not support effort settings.
     fn with_generic_effort(self, _effort: i32) -> Self {
         self
     }
 
     /// Enable or disable lossless encoding.
     ///
-    /// Default no-op. When lossless is enabled, quality is ignored.
+    /// When lossless is enabled, quality is ignored.
+    ///
+    /// # Note
+    ///
+    /// The default implementation is a no-op. Not all codecs support lossless
+    /// mode. Use [`is_lossless()`](EncoderConfig::is_lossless) after calling
+    /// this to verify the codec accepted the value -- it returns `None` if the
+    /// codec does not support lossless encoding.
     fn with_lossless(self, _lossless: bool) -> Self {
         self
     }
 
-    /// Set independent alpha channel quality on a calibrated 0.0–100.0 scale.
+    /// Set independent alpha channel quality on a calibrated 0.0--100.0 scale.
     ///
-    /// Default no-op.
+    /// # Note
+    ///
+    /// The default implementation is a no-op. Not all codecs support separate
+    /// alpha quality. Use [`alpha_quality()`](EncoderConfig::alpha_quality) after
+    /// calling this to verify the codec accepted the value -- it returns `None`
+    /// if the codec does not support alpha quality settings.
     fn with_alpha_quality(self, _quality: f32) -> Self {
         self
     }

--- a/src/traits/encoding.rs
+++ b/src/traits/encoding.rs
@@ -150,8 +150,13 @@ pub trait EncodeJob: Sized {
 
     /// Set encode security policy (controls metadata embedding, etc.).
     ///
-    /// Default no-op. Codecs that support policy check the flags in
-    /// [`EncodePolicy`](crate::encode::EncodePolicy) to decide what to embed.
+    /// # Note
+    ///
+    /// The default implementation is a no-op that returns `self` unchanged.
+    /// Not all codecs implement policy support. Check the codec's documentation
+    /// or [`EncodeCapabilities`](crate::EncodeCapabilities) to determine whether
+    /// the codec honors policy settings. Calling this on a codec that does not
+    /// implement it will silently have no effect.
     fn with_policy(self, _policy: crate::EncodePolicy) -> Self {
         self
     }


### PR DESCRIPTION
## Summary
- Handle ISOBMFF `box_size=0` (extends to EOF) and `box_size=1` (64-bit extended size) in `scan_compat_brands` format detection (M2)
- Replace panicking `.expect()` in `DecodeJobShim::take()`/`as_ref()` and `EncodeJobShim::take()` with `Result` returns and descriptive error messages (M3)
- Replace panicking `.expect()` in `Encoder::encode_srgba8` default impl with `.map_err()` error return (M4)
- Add `# Note` doc warnings that `DecodeJob::with_policy` and `EncodeJob::with_policy` default implementations are silent no-ops (M5)
- Add `# Note` doc warnings that `EncoderConfig::with_generic_quality`, `with_generic_effort`, `with_lossless`, and `with_alpha_quality` default implementations are silent no-ops, with guidance to use getter methods for verification (M6)

**Skipped:** M1 (`FormatSet` missing bits) is in the `zencodecs` crate (separate repo), needs its own PR.

## Test plan
- [x] All existing tests pass (`cargo test`)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean