### PR TITLE
Add icc_extract_cicp() and ColorAuthority to SourceColor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,10 @@ jobs:
             -e 's|path = "\.\./zenpixels/zenpixels-convert"|git = "https://github.com/imazen/zenpixels"|g' \
             Cargo.toml > Cargo.toml.ci && \
             mv Cargo.toml.ci Cargo.toml
-          printf '\n[patch.crates-io]\nzenpixels = { git = "https://github.com/imazen/zenpixels" }\nzenpixels-convert = { git = "https://github.com/imazen/zenpixels" }\n' >> Cargo.toml
+          # Add [patch.crates-io] only if not already present (color-authority branch has one)
+          if ! grep -q '\[patch.crates-io\]' Cargo.toml; then
+            printf '\n[patch.crates-io]\nzenpixels = { git = "https://github.com/imazen/zenpixels" }\nzenpixels-convert = { git = "https://github.com/imazen/zenpixels" }\n' >> Cargo.toml
+          fi
           rm -f Cargo.lock
 
       - name: Test
@@ -94,7 +97,10 @@ jobs:
             -e 's|path = "\.\./zenpixels/zenpixels-convert"|git = "https://github.com/imazen/zenpixels"|g' \
             Cargo.toml > Cargo.toml.ci && \
             mv Cargo.toml.ci Cargo.toml
-          printf '\n[patch.crates-io]\nzenpixels = { git = "https://github.com/imazen/zenpixels" }\nzenpixels-convert = { git = "https://github.com/imazen/zenpixels" }\n' >> Cargo.toml
+          # Add [patch.crates-io] only if not already present (color-authority branch has one)
+          if ! grep -q '\[patch.crates-io\]' Cargo.toml; then
+            printf '\n[patch.crates-io]\nzenpixels = { git = "https://github.com/imazen/zenpixels" }\nzenpixels-convert = { git = "https://github.com/imazen/zenpixels" }\n' >> Cargo.toml
+          fi
           rm -f Cargo.lock
 
       - name: Test (i686/QEMU)
@@ -128,7 +134,10 @@ jobs:
             -e 's|path = "\.\./zenpixels/zenpixels-convert"|git = "https://github.com/imazen/zenpixels"|g' \
             Cargo.toml > Cargo.toml.ci && \
             mv Cargo.toml.ci Cargo.toml
-          printf '\n[patch.crates-io]\nzenpixels = { git = "https://github.com/imazen/zenpixels" }\nzenpixels-convert = { git = "https://github.com/imazen/zenpixels" }\n' >> Cargo.toml
+          # Add [patch.crates-io] only if not already present (color-authority branch has one)
+          if ! grep -q '\[patch.crates-io\]' Cargo.toml; then
+            printf '\n[patch.crates-io]\nzenpixels = { git = "https://github.com/imazen/zenpixels" }\nzenpixels-convert = { git = "https://github.com/imazen/zenpixels" }\n' >> Cargo.toml
+          fi
           rm -f Cargo.lock
 
       - name: Check WASM (no_std)
@@ -162,7 +171,10 @@ jobs:
             -e 's|path = "\.\./zenpixels/zenpixels-convert"|git = "https://github.com/imazen/zenpixels"|g' \
             Cargo.toml > Cargo.toml.ci && \
             mv Cargo.toml.ci Cargo.toml
-          printf '\n[patch.crates-io]\nzenpixels = { git = "https://github.com/imazen/zenpixels" }\nzenpixels-convert = { git = "https://github.com/imazen/zenpixels" }\n' >> Cargo.toml
+          # Add [patch.crates-io] only if not already present (color-authority branch has one)
+          if ! grep -q '\[patch.crates-io\]' Cargo.toml; then
+            printf '\n[patch.crates-io]\nzenpixels = { git = "https://github.com/imazen/zenpixels" }\nzenpixels-convert = { git = "https://github.com/imazen/zenpixels" }\n' >> Cargo.toml
+          fi
           rm -f Cargo.lock
 
       - name: Clippy
@@ -246,7 +258,10 @@ jobs:
             -e 's|path = "\.\./zenpixels/zenpixels-convert"|git = "https://github.com/imazen/zenpixels"|g' \
             Cargo.toml > Cargo.toml.ci && \
             mv Cargo.toml.ci Cargo.toml
-          printf '\n[patch.crates-io]\nzenpixels = { git = "https://github.com/imazen/zenpixels" }\nzenpixels-convert = { git = "https://github.com/imazen/zenpixels" }\n' >> Cargo.toml
+          # Add [patch.crates-io] only if not already present (color-authority branch has one)
+          if ! grep -q '\[patch.crates-io\]' Cargo.toml; then
+            printf '\n[patch.crates-io]\nzenpixels = { git = "https://github.com/imazen/zenpixels" }\nzenpixels-convert = { git = "https://github.com/imazen/zenpixels" }\n' >> Cargo.toml
+          fi
           rm -f Cargo.lock
 
       - name: Check semver
@@ -285,7 +300,10 @@ jobs:
             -e 's|path = "\.\./zenpixels/zenpixels-convert"|git = "https://github.com/imazen/zenpixels"|g' \
             Cargo.toml > Cargo.toml.ci && \
             mv Cargo.toml.ci Cargo.toml
-          printf '\n[patch.crates-io]\nzenpixels = { git = "https://github.com/imazen/zenpixels" }\nzenpixels-convert = { git = "https://github.com/imazen/zenpixels" }\n' >> Cargo.toml
+          # Add [patch.crates-io] only if not already present (color-authority branch has one)
+          if ! grep -q '\[patch.crates-io\]' Cargo.toml; then
+            printf '\n[patch.crates-io]\nzenpixels = { git = "https://github.com/imazen/zenpixels" }\nzenpixels-convert = { git = "https://github.com/imazen/zenpixels" }\n' >> Cargo.toml
+          fi
           rm -f Cargo.lock
 
       - name: Generate coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,12 +215,18 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      - name: Patch zenpixels to git ref with lowered MSRV
+      - name: Patch path deps to git refs
         shell: bash
         run: |
-          # zenpixels on crates.io still declares rust-version 1.93;
-          # patch to git main (which has lowered MSRV) until next publish.
-          printf '\n[patch.crates-io]\nzenpixels = { git = "https://github.com/imazen/zenpixels" }\n' >> Cargo.toml
+          sed \
+            -e 's|path = "\.\./zenpixels/zenpixels"|git = "https://github.com/imazen/zenpixels"|g' \
+            -e 's|path = "\.\./zenpixels/zenpixels-convert"|git = "https://github.com/imazen/zenpixels"|g' \
+            Cargo.toml > Cargo.toml.ci && \
+            mv Cargo.toml.ci Cargo.toml
+          # Add [patch.crates-io] only if not already present
+          if ! grep -q '\[patch.crates-io\]' Cargo.toml; then
+            printf '\n[patch.crates-io]\nzenpixels = { git = "https://github.com/imazen/zenpixels" }\n' >> Cargo.toml
+          fi
           rm -f Cargo.lock
 
       - name: Check MSRV

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,7 @@ whereat = { version = "0.1.5"}
 thiserror = "2"
 walkdir = "2.5.0"
 rayon = "1.10.0"
+
+[patch.crates-io]
+# ColorAuthority not yet published to crates.io; remove when zenpixels > 0.2.2 is released.
+zenpixels = { path = "../zenpixels/zenpixels" }

--- a/src/icc.rs
+++ b/src/icc.rs
@@ -1,0 +1,197 @@
+//! Lightweight ICC profile inspection.
+//!
+//! Extracts specific tags from ICC profile bytes without a full parse.
+//! No dependencies beyond `core` — suitable for `no_std` environments.
+
+/// Extract CICP (Coding-Independent Code Points) from an ICC profile's tag table.
+///
+/// Scans the ICC tag table for a `cicp` tag (ICC v4.4+, 12 bytes) and returns
+/// the four CICP fields if found. Returns `None` for ICC v2 profiles (which
+/// never contain cicp tags), profiles without a cicp tag, or malformed input.
+///
+/// This is a lightweight operation (~100ns) that reads only the 128-byte header
+/// and tag table entries — no full profile parse required.
+///
+/// # Returns
+///
+/// `Some((color_primaries, transfer_characteristics, matrix_coefficients, full_range))`
+/// if a valid cicp tag is found, `None` otherwise.
+pub fn icc_extract_cicp(data: &[u8]) -> Option<(u8, u8, u8, bool)> {
+    // ICC profiles: 128-byte header, then tag count at offset 128.
+    if data.len() < 132 {
+        return None;
+    }
+    // Validate ICC signature at offset 36.
+    if data[36..40] != *b"acsp" {
+        return None;
+    }
+
+    let tag_count = u32::from_be_bytes(data[128..132].try_into().ok()?) as usize;
+    // Cap to prevent DoS from malformed tag count.
+    let tag_count = tag_count.min(200);
+
+    // Tag table starts at offset 132, each entry is 12 bytes:
+    //   [0..4]  signature
+    //   [4..8]  data offset from profile start
+    //   [8..12] data size
+    for i in 0..tag_count {
+        let entry_offset = 132 + i * 12;
+        let entry = data.get(entry_offset..entry_offset + 12)?;
+
+        if entry[..4] != *b"cicp" {
+            continue;
+        }
+
+        let data_offset = u32::from_be_bytes(entry[4..8].try_into().ok()?) as usize;
+        let data_size = u32::from_be_bytes(entry[8..12].try_into().ok()?) as usize;
+
+        if data_size < 12 {
+            return None;
+        }
+
+        let tag_data = data.get(data_offset..data_offset + 12)?;
+
+        // Tag data starts with type signature (should also be "cicp").
+        if tag_data[..4] != *b"cicp" {
+            return None;
+        }
+        // Bytes 4..8 are reserved (should be zero).
+        // Bytes 8..12 are the four CICP fields.
+        return Some((tag_data[8], tag_data[9], tag_data[10], tag_data[11] != 0));
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal valid ICC profile with a cicp tag for testing.
+    fn build_icc_with_cicp(cp: u8, tc: u8, mc: u8, fr: bool) -> alloc::vec::Vec<u8> {
+        let mut data = alloc::vec![0u8; 256];
+        // Profile size at offset 0.
+        let size = data.len() as u32;
+        data[0..4].copy_from_slice(&size.to_be_bytes());
+        // 'acsp' signature at offset 36.
+        data[36..40].copy_from_slice(b"acsp");
+        // Tag count = 1 at offset 128.
+        data[128..132].copy_from_slice(&1u32.to_be_bytes());
+        // Tag entry at offset 132: signature='cicp', offset=144, size=12.
+        data[132..136].copy_from_slice(b"cicp");
+        data[136..140].copy_from_slice(&144u32.to_be_bytes());
+        data[140..144].copy_from_slice(&12u32.to_be_bytes());
+        // Tag data at offset 144: type='cicp', reserved=0, then 4 CICP bytes.
+        data[144..148].copy_from_slice(b"cicp");
+        // reserved bytes 148..152 are already 0
+        data[152] = cp;
+        data[153] = tc;
+        data[154] = mc;
+        data[155] = if fr { 1 } else { 0 };
+        data
+    }
+
+    #[test]
+    fn extract_cicp_srgb() {
+        let icc = build_icc_with_cicp(1, 13, 0, true);
+        assert_eq!(icc_extract_cicp(&icc), Some((1, 13, 0, true)));
+    }
+
+    #[test]
+    fn extract_cicp_pq() {
+        let icc = build_icc_with_cicp(9, 16, 0, true);
+        assert_eq!(icc_extract_cicp(&icc), Some((9, 16, 0, true)));
+    }
+
+    #[test]
+    fn extract_cicp_hlg() {
+        let icc = build_icc_with_cicp(9, 18, 0, false);
+        assert_eq!(icc_extract_cicp(&icc), Some((9, 18, 0, false)));
+    }
+
+    #[test]
+    fn no_cicp_in_empty_profile() {
+        assert_eq!(icc_extract_cicp(&[]), None);
+    }
+
+    #[test]
+    fn no_cicp_in_short_data() {
+        assert_eq!(icc_extract_cicp(&[0; 100]), None);
+    }
+
+    #[test]
+    fn no_cicp_without_acsp_signature() {
+        let mut icc = build_icc_with_cicp(1, 13, 0, true);
+        icc[36..40].copy_from_slice(b"xxxx");
+        assert_eq!(icc_extract_cicp(&icc), None);
+    }
+
+    #[test]
+    fn no_cicp_when_tag_missing() {
+        let mut data = alloc::vec![0u8; 256];
+        let size = data.len() as u32;
+        data[0..4].copy_from_slice(&size.to_be_bytes());
+        data[36..40].copy_from_slice(b"acsp");
+        // Tag count = 1 but tag is 'desc' not 'cicp'
+        data[128..132].copy_from_slice(&1u32.to_be_bytes());
+        data[132..136].copy_from_slice(b"desc");
+        data[136..140].copy_from_slice(&144u32.to_be_bytes());
+        data[140..144].copy_from_slice(&12u32.to_be_bytes());
+        assert_eq!(icc_extract_cicp(&data), None);
+    }
+
+    #[test]
+    fn no_cicp_when_tag_data_too_small() {
+        let mut icc = build_icc_with_cicp(1, 13, 0, true);
+        // Set tag data size to 8 (too small, need 12)
+        icc[140..144].copy_from_slice(&8u32.to_be_bytes());
+        assert_eq!(icc_extract_cicp(&icc), None);
+    }
+
+    #[test]
+    fn no_cicp_when_data_offset_out_of_bounds() {
+        let mut icc = build_icc_with_cicp(1, 13, 0, true);
+        // Set data offset beyond profile
+        icc[136..140].copy_from_slice(&999u32.to_be_bytes());
+        assert_eq!(icc_extract_cicp(&icc), None);
+    }
+
+    #[test]
+    fn no_cicp_when_tag_type_mismatch() {
+        let mut icc = build_icc_with_cicp(1, 13, 0, true);
+        // Corrupt the type signature in tag data
+        icc[144..148].copy_from_slice(b"xxxx");
+        assert_eq!(icc_extract_cicp(&icc), None);
+    }
+
+    #[test]
+    fn malicious_tag_count_capped() {
+        // Build a profile where the cicp tag is at index 201 (past the cap of 200).
+        // Tag entries start at 132; each is 12 bytes. Tag at index 201 → offset 132 + 201*12 = 2544.
+        // We need a buffer large enough to hold the cicp tag data too.
+        const CICP_IDX: usize = 201;
+        const ENTRY_OFFSET: usize = 132 + CICP_IDX * 12;
+        const DATA_OFFSET: usize = ENTRY_OFFSET + 12;
+        let buf_len = DATA_OFFSET + 12;
+        let mut data = alloc::vec![0u8; buf_len];
+        let size = data.len() as u32;
+        data[0..4].copy_from_slice(&size.to_be_bytes());
+        data[36..40].copy_from_slice(b"acsp");
+        // Claim there are 202 tags.
+        data[128..132].copy_from_slice(&202u32.to_be_bytes());
+        // Put cicp tag at index 201.
+        data[ENTRY_OFFSET..ENTRY_OFFSET + 4].copy_from_slice(b"cicp");
+        data[ENTRY_OFFSET + 4..ENTRY_OFFSET + 8]
+            .copy_from_slice(&(DATA_OFFSET as u32).to_be_bytes());
+        data[ENTRY_OFFSET + 8..ENTRY_OFFSET + 12].copy_from_slice(&12u32.to_be_bytes());
+        data[DATA_OFFSET..DATA_OFFSET + 4].copy_from_slice(b"cicp");
+        data[DATA_OFFSET + 8] = 1;
+        data[DATA_OFFSET + 9] = 13;
+        data[DATA_OFFSET + 10] = 0;
+        data[DATA_OFFSET + 11] = 1;
+        // With an absurd claimed tag count, the cap prevents reaching index 201.
+        data[128..132].copy_from_slice(&u32::MAX.to_be_bytes());
+        // Cap of 200 means index 201 is never reached → returns None.
+        assert_eq!(icc_extract_cicp(&data), None);
+    }
+}

--- a/src/info.rs
+++ b/src/info.rs
@@ -292,7 +292,7 @@ impl SourceColor {
     ///
     /// When true, a colorimetric CMS transform to an SDR destination will
     /// clip highlights — tone mapping is required first.
-    pub fn is_hdr(&self) -> bool {
+    pub fn has_hdr_transfer(&self) -> bool {
         if let Some(c) = self.cicp
             && matches!(c.transfer_characteristics, 16 | 18)
         {
@@ -957,7 +957,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // SourceColor + ColorAuthority + is_hdr() tests
+    // SourceColor + ColorAuthority + has_hdr_transfer() tests
     // -----------------------------------------------------------------------
 
     /// Build a minimal ICC profile with a cicp tag (reuse icc.rs helper logic).
@@ -1010,88 +1010,88 @@ mod tests {
         assert_eq!(info.source_color.color_authority, ColorAuthority::Cicp);
     }
 
-    // --- is_hdr() from CICP ---
+    // --- has_hdr_transfer() from CICP ---
 
     #[test]
-    fn is_hdr_cicp_pq() {
+    fn has_hdr_transfer_cicp_pq() {
         let sc = SourceColor::default().with_cicp(Cicp::BT2100_PQ);
-        assert!(sc.is_hdr());
+        assert!(sc.has_hdr_transfer());
     }
 
     #[test]
-    fn is_hdr_cicp_hlg() {
+    fn has_hdr_transfer_cicp_hlg() {
         let sc = SourceColor::default().with_cicp(Cicp::BT2100_HLG);
-        assert!(sc.is_hdr());
+        assert!(sc.has_hdr_transfer());
     }
 
     #[test]
-    fn is_hdr_cicp_srgb_is_false() {
+    fn has_hdr_transfer_cicp_srgb_is_false() {
         let sc = SourceColor::default().with_cicp(Cicp::SRGB);
-        assert!(!sc.is_hdr());
+        assert!(!sc.has_hdr_transfer());
     }
 
     #[test]
-    fn is_hdr_cicp_p3_is_false() {
+    fn has_hdr_transfer_cicp_p3_is_false() {
         let sc = SourceColor::default().with_cicp(Cicp::DISPLAY_P3);
-        assert!(!sc.is_hdr());
+        assert!(!sc.has_hdr_transfer());
     }
 
     #[test]
-    fn is_hdr_cicp_bt709_is_false() {
+    fn has_hdr_transfer_cicp_bt709_is_false() {
         let sc = SourceColor::default().with_cicp(Cicp::new(1, 1, 0, true));
-        assert!(!sc.is_hdr());
+        assert!(!sc.has_hdr_transfer());
     }
 
     #[test]
-    fn is_hdr_cicp_linear_is_false() {
+    fn has_hdr_transfer_cicp_linear_is_false() {
         let sc = SourceColor::default().with_cicp(Cicp::new(1, 8, 0, true));
-        assert!(!sc.is_hdr());
+        assert!(!sc.has_hdr_transfer());
     }
 
-    // --- is_hdr() from ICC cicp tag ---
+    // --- has_hdr_transfer() from ICC cicp tag ---
 
     #[test]
-    fn is_hdr_icc_pq_tag() {
+    fn has_hdr_transfer_icc_pq_tag() {
         let icc = build_icc_with_cicp(9, 16, 0, true);
         let sc = SourceColor::default().with_icc_profile(icc);
-        assert!(sc.is_hdr());
+        assert!(sc.has_hdr_transfer());
     }
 
     #[test]
-    fn is_hdr_icc_hlg_tag() {
+    fn has_hdr_transfer_icc_hlg_tag() {
         let icc = build_icc_with_cicp(9, 18, 0, false);
         let sc = SourceColor::default().with_icc_profile(icc);
-        assert!(sc.is_hdr());
+        assert!(sc.has_hdr_transfer());
     }
 
     #[test]
-    fn is_hdr_icc_srgb_tag_is_false() {
+    fn has_hdr_transfer_icc_srgb_tag_is_false() {
         let icc = build_icc_with_cicp(1, 13, 0, true);
         let sc = SourceColor::default().with_icc_profile(icc);
-        assert!(!sc.is_hdr());
+        assert!(!sc.has_hdr_transfer());
     }
 
     #[test]
-    fn is_hdr_icc_no_cicp_tag_is_false() {
+    fn has_hdr_transfer_icc_no_cicp_tag_is_false() {
         let icc = build_icc_no_cicp();
         let sc = SourceColor::default().with_icc_profile(icc);
-        assert!(!sc.is_hdr());
+        assert!(!sc.has_hdr_transfer());
     }
 
-    // --- is_hdr() priority: CICP checked before ICC ---
+    // --- has_hdr_transfer() priority: CICP checked before ICC ---
 
     #[test]
-    fn is_hdr_cicp_wins_over_icc() {
+    fn has_hdr_transfer_cicp_wins_over_icc() {
         // CICP says PQ, ICC says sRGB → CICP checked first → HDR
         let icc = build_icc_with_cicp(1, 13, 0, true);
         let sc = SourceColor::default()
             .with_cicp(Cicp::BT2100_PQ)
             .with_icc_profile(icc);
-        assert!(sc.is_hdr());
+        assert!(sc.has_hdr_transfer());
     }
 
     #[test]
-    fn is_hdr_cicp_sdr_but_icc_hdr_still_detects() {
+    fn has_hdr_transfer_cicp_sdr_but_icc_hdr_still_detects() {
         // CICP says sRGB (tc=13) → first check doesn't match (not PQ/HLG).
         // Falls through to ICC check → finds PQ cicp tag → HDR.
         // Conservative: if ANY signal says HDR, we report HDR.
@@ -1099,38 +1099,38 @@ mod tests {
         let sc = SourceColor::default()
             .with_cicp(Cicp::SRGB)
             .with_icc_profile(icc);
-        assert!(sc.is_hdr());
+        assert!(sc.has_hdr_transfer());
     }
 
     #[test]
-    fn is_hdr_cicp_pq_short_circuits_before_icc() {
+    fn has_hdr_transfer_cicp_pq_short_circuits_before_icc() {
         // CICP says PQ → first check matches → returns true immediately.
         // Even garbage ICC doesn't prevent detection.
         let sc = SourceColor::default()
             .with_cicp(Cicp::BT2100_PQ)
             .with_icc_profile(alloc::vec![0xFF; 10]);
-        assert!(sc.is_hdr());
+        assert!(sc.has_hdr_transfer());
     }
 
-    // --- is_hdr() with no metadata ---
+    // --- has_hdr_transfer() with no metadata ---
 
     #[test]
-    fn is_hdr_no_metadata_is_false() {
+    fn has_hdr_transfer_no_metadata_is_false() {
         let sc = SourceColor::default();
-        assert!(!sc.is_hdr());
+        assert!(!sc.has_hdr_transfer());
     }
 
-    // --- is_hdr() edge cases ---
+    // --- has_hdr_transfer() edge cases ---
 
     #[test]
-    fn is_hdr_empty_icc_is_false() {
+    fn has_hdr_transfer_empty_icc_is_false() {
         let sc = SourceColor::default().with_icc_profile(alloc::vec![]);
-        assert!(!sc.is_hdr());
+        assert!(!sc.has_hdr_transfer());
     }
 
     #[test]
-    fn is_hdr_garbage_icc_is_false() {
+    fn has_hdr_transfer_garbage_icc_is_false() {
         let sc = SourceColor::default().with_icc_profile(alloc::vec![0xFF; 200]);
-        assert!(!sc.is_hdr());
+        assert!(!sc.has_hdr_transfer());
     }
 }

--- a/src/info.rs
+++ b/src/info.rs
@@ -10,7 +10,7 @@ use crate::detect::SourceEncodingDetails;
 use crate::gainmap::GainMapPresence;
 use crate::metadata::Metadata;
 use crate::{ImageFormat, Orientation};
-use zenpixels::{ColorPrimaries, TransferFunction};
+use zenpixels::{ColorAuthority, ColorPrimaries, TransferFunction};
 
 // Re-export color types from zenpixels — the canonical definitions.
 pub use zenpixels::Cicp;
@@ -211,15 +211,21 @@ pub use zenpixels::{ContentLightLevel, MasteringDisplay};
 pub struct SourceColor {
     /// CICP color description (ITU-T H.273).
     ///
-    /// When present, describes the color space without requiring an ICC
-    /// profile. Both CICP and ICC may be present — CICP takes precedence
-    /// per AVIF/HEIF specs, but callers should use ICC when CICP is absent.
+    /// When present, describes the color space using code points for primaries,
+    /// transfer function, and matrix coefficients. Both CICP and ICC may be
+    /// present — which takes precedence depends on the format (see
+    /// [`color_authority`](Self::color_authority)).
     pub cicp: Option<Cicp>,
     /// Embedded ICC color profile.
     ///
     /// Stored as `Arc<[u8]>` for cheap sharing across pipeline stages
     /// and pixel slices. Accepts `Vec<u8>` via [`with_icc_profile()`](Self::with_icc_profile).
     pub icc_profile: Option<Arc<[u8]>>,
+    /// Which color field is authoritative for CMS transforms.
+    ///
+    /// Set by the codec during decode based on the format's spec.
+    /// See [`ColorAuthority`] for per-format guidance.
+    pub color_authority: ColorAuthority,
     /// Bits per channel (e.g. 8, 10, 12, 16, 32).
     ///
     /// `None` if unknown (e.g. from a header-only probe that doesn't
@@ -270,6 +276,34 @@ impl SourceColor {
     pub fn with_mastering_display(mut self, mdcv: MasteringDisplay) -> Self {
         self.mastering_display = Some(mdcv);
         self
+    }
+
+    /// Set which color metadata is authoritative for CMS transforms.
+    pub fn with_color_authority(mut self, authority: ColorAuthority) -> Self {
+        self.color_authority = authority;
+        self
+    }
+
+    /// Whether this content uses an HDR transfer function (PQ or HLG).
+    ///
+    /// Checks CICP first (cheap), then falls back to inspecting the ICC
+    /// profile's cicp tag via lightweight tag table scan. Does NOT require
+    /// a full ICC profile parse.
+    ///
+    /// When true, a colorimetric CMS transform to an SDR destination will
+    /// clip highlights — tone mapping is required first.
+    pub fn is_hdr(&self) -> bool {
+        if let Some(c) = self.cicp
+            && matches!(c.transfer_characteristics, 16 | 18)
+        {
+            return true;
+        }
+        if let Some(ref icc) = self.icc_profile
+            && let Some((_, tc, _, _)) = crate::icc::icc_extract_cicp(icc)
+        {
+            return matches!(tc, 16 | 18);
+        }
+        false
     }
 
     /// Derive the transfer function from CICP metadata.
@@ -541,6 +575,12 @@ impl ImageInfo {
     /// Accepts `Vec<u8>`, `&[u8]`, or `Arc<[u8]>`.
     pub fn with_icc_profile(mut self, icc: impl Into<Arc<[u8]>>) -> Self {
         self.source_color.icc_profile = Some(icc.into());
+        self
+    }
+
+    /// Set which color metadata is authoritative. Convenience for `source_color.color_authority`.
+    pub fn with_color_authority(mut self, authority: ColorAuthority) -> Self {
+        self.source_color.color_authority = authority;
         self
     }
 

--- a/src/info.rs
+++ b/src/info.rs
@@ -955,4 +955,182 @@ mod tests {
         assert_eq!(Cicp::matrix_coefficients_name(6), "BT.601");
         assert_eq!(Cicp::matrix_coefficients_name(9), "BT.2020 NCL");
     }
+
+    // -----------------------------------------------------------------------
+    // SourceColor + ColorAuthority + is_hdr() tests
+    // -----------------------------------------------------------------------
+
+    /// Build a minimal ICC profile with a cicp tag (reuse icc.rs helper logic).
+    fn build_icc_with_cicp(cp: u8, tc: u8, mc: u8, fr: bool) -> alloc::vec::Vec<u8> {
+        let mut data = alloc::vec![0u8; 256];
+        data[0..4].copy_from_slice(&256u32.to_be_bytes());
+        data[36..40].copy_from_slice(b"acsp");
+        data[128..132].copy_from_slice(&1u32.to_be_bytes());
+        data[132..136].copy_from_slice(b"cicp");
+        data[136..140].copy_from_slice(&144u32.to_be_bytes());
+        data[140..144].copy_from_slice(&12u32.to_be_bytes());
+        data[144..148].copy_from_slice(b"cicp");
+        data[152] = cp;
+        data[153] = tc;
+        data[154] = mc;
+        data[155] = if fr { 1 } else { 0 };
+        data
+    }
+
+    /// Build a minimal ICC profile without a cicp tag.
+    fn build_icc_no_cicp() -> alloc::vec::Vec<u8> {
+        let mut data = alloc::vec![0u8; 256];
+        data[0..4].copy_from_slice(&256u32.to_be_bytes());
+        data[36..40].copy_from_slice(b"acsp");
+        data[128..132].copy_from_slice(&1u32.to_be_bytes());
+        data[132..136].copy_from_slice(b"desc");
+        data[136..140].copy_from_slice(&144u32.to_be_bytes());
+        data[140..144].copy_from_slice(&12u32.to_be_bytes());
+        data
+    }
+
+    #[test]
+    fn source_color_default_is_icc_authority() {
+        let sc = SourceColor::default();
+        assert_eq!(sc.color_authority, ColorAuthority::Icc);
+        assert!(sc.cicp.is_none());
+        assert!(sc.icc_profile.is_none());
+    }
+
+    #[test]
+    fn source_color_with_color_authority() {
+        let sc = SourceColor::default().with_color_authority(ColorAuthority::Cicp);
+        assert_eq!(sc.color_authority, ColorAuthority::Cicp);
+    }
+
+    #[test]
+    fn image_info_with_color_authority() {
+        let info =
+            ImageInfo::new(1, 1, ImageFormat::Png).with_color_authority(ColorAuthority::Cicp);
+        assert_eq!(info.source_color.color_authority, ColorAuthority::Cicp);
+    }
+
+    // --- is_hdr() from CICP ---
+
+    #[test]
+    fn is_hdr_cicp_pq() {
+        let sc = SourceColor::default().with_cicp(Cicp::BT2100_PQ);
+        assert!(sc.is_hdr());
+    }
+
+    #[test]
+    fn is_hdr_cicp_hlg() {
+        let sc = SourceColor::default().with_cicp(Cicp::BT2100_HLG);
+        assert!(sc.is_hdr());
+    }
+
+    #[test]
+    fn is_hdr_cicp_srgb_is_false() {
+        let sc = SourceColor::default().with_cicp(Cicp::SRGB);
+        assert!(!sc.is_hdr());
+    }
+
+    #[test]
+    fn is_hdr_cicp_p3_is_false() {
+        let sc = SourceColor::default().with_cicp(Cicp::DISPLAY_P3);
+        assert!(!sc.is_hdr());
+    }
+
+    #[test]
+    fn is_hdr_cicp_bt709_is_false() {
+        let sc = SourceColor::default().with_cicp(Cicp::new(1, 1, 0, true));
+        assert!(!sc.is_hdr());
+    }
+
+    #[test]
+    fn is_hdr_cicp_linear_is_false() {
+        let sc = SourceColor::default().with_cicp(Cicp::new(1, 8, 0, true));
+        assert!(!sc.is_hdr());
+    }
+
+    // --- is_hdr() from ICC cicp tag ---
+
+    #[test]
+    fn is_hdr_icc_pq_tag() {
+        let icc = build_icc_with_cicp(9, 16, 0, true);
+        let sc = SourceColor::default().with_icc_profile(icc);
+        assert!(sc.is_hdr());
+    }
+
+    #[test]
+    fn is_hdr_icc_hlg_tag() {
+        let icc = build_icc_with_cicp(9, 18, 0, false);
+        let sc = SourceColor::default().with_icc_profile(icc);
+        assert!(sc.is_hdr());
+    }
+
+    #[test]
+    fn is_hdr_icc_srgb_tag_is_false() {
+        let icc = build_icc_with_cicp(1, 13, 0, true);
+        let sc = SourceColor::default().with_icc_profile(icc);
+        assert!(!sc.is_hdr());
+    }
+
+    #[test]
+    fn is_hdr_icc_no_cicp_tag_is_false() {
+        let icc = build_icc_no_cicp();
+        let sc = SourceColor::default().with_icc_profile(icc);
+        assert!(!sc.is_hdr());
+    }
+
+    // --- is_hdr() priority: CICP checked before ICC ---
+
+    #[test]
+    fn is_hdr_cicp_wins_over_icc() {
+        // CICP says PQ, ICC says sRGB → CICP checked first → HDR
+        let icc = build_icc_with_cicp(1, 13, 0, true);
+        let sc = SourceColor::default()
+            .with_cicp(Cicp::BT2100_PQ)
+            .with_icc_profile(icc);
+        assert!(sc.is_hdr());
+    }
+
+    #[test]
+    fn is_hdr_cicp_sdr_but_icc_hdr_still_detects() {
+        // CICP says sRGB (tc=13) → first check doesn't match (not PQ/HLG).
+        // Falls through to ICC check → finds PQ cicp tag → HDR.
+        // Conservative: if ANY signal says HDR, we report HDR.
+        let icc = build_icc_with_cicp(9, 16, 0, true);
+        let sc = SourceColor::default()
+            .with_cicp(Cicp::SRGB)
+            .with_icc_profile(icc);
+        assert!(sc.is_hdr());
+    }
+
+    #[test]
+    fn is_hdr_cicp_pq_short_circuits_before_icc() {
+        // CICP says PQ → first check matches → returns true immediately.
+        // Even garbage ICC doesn't prevent detection.
+        let sc = SourceColor::default()
+            .with_cicp(Cicp::BT2100_PQ)
+            .with_icc_profile(alloc::vec![0xFF; 10]);
+        assert!(sc.is_hdr());
+    }
+
+    // --- is_hdr() with no metadata ---
+
+    #[test]
+    fn is_hdr_no_metadata_is_false() {
+        let sc = SourceColor::default();
+        assert!(!sc.is_hdr());
+    }
+
+    // --- is_hdr() edge cases ---
+
+    #[test]
+    fn is_hdr_empty_icc_is_false() {
+        let sc = SourceColor::default().with_icc_profile(alloc::vec![]);
+        assert!(!sc.is_hdr());
+    }
+
+    #[test]
+    fn is_hdr_garbage_icc_is_false() {
+        let sc = SourceColor::default().with_icc_profile(alloc::vec![0xFF; 200]);
+        assert!(!sc.is_hdr());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,8 @@ mod format;
 pub mod gainmap;
 /// Codec implementation helpers (not consumer API).
 pub mod helpers;
+/// Lightweight ICC profile inspection (tag extraction, no full parse).
+pub mod icc;
 mod info;
 mod limits;
 mod metadata;
@@ -66,6 +68,7 @@ pub use format::{ImageFormat, ImageFormatDefinition, ImageFormatRegistry};
 pub use gainmap::{
     GainMapChannel, GainMapDirection, GainMapInfo, GainMapParams, GainMapPresence, Iso21496Format,
 };
+pub use icc::icc_extract_cicp;
 pub use info::{
     Cicp, ContentLightLevel, ImageInfo, ImageSequence, MasteringDisplay, Resolution,
     ResolutionUnit, SourceColor, Supplements,
@@ -74,6 +77,7 @@ pub use limits::{LimitExceeded, ResourceLimits, ThreadingPolicy};
 pub use metadata::Metadata;
 pub use orientation::{Orientation, OrientationHint};
 pub use output::{AnimationFrame, OwnedAnimationFrame};
+pub use zenpixels::ColorAuthority;
 
 pub use capabilities::UnsupportedOperation;
 pub use detect::SourceEncodingDetails;


### PR DESCRIPTION
## Summary

- Adds `icc_extract_cicp()` — lightweight ICC tag table scanner (~30 lines, `no_std`, zero deps) that extracts CICP codes from ICC v4.4+ profiles without a full parse
- Adds `color_authority` field to `SourceColor` (from zenpixels `ColorAuthority`)
- Adds `SourceColor::has_hdr_transfer()` — checks CICP for PQ/HLG, falls back to scanning ICC's cicp tag
- Adds `ImageInfo::with_color_authority()` convenience method

## Motivation

Depends on imazen/zenpixels#4.

CMS consumers need to know which color metadata field to trust. `ColorAuthority` (from zenpixels) captures the format-specific precedence decision. The codec sets it during decode; the CMS reads it when building transforms.

`has_hdr_transfer()` detects PQ/HLG transfer functions so CMS consumers can reject/warn before attempting a colorimetric transform that would clip highlights. It works even for JPEG/TIFF with HDR ICC profiles (no container CICP) by scanning the ICC's embedded cicp tag. The name is precise — it checks for PQ/HLG transfers specifically, not arbitrary HDR content like linear f32 > 1.0.

`icc_extract_cicp()` reads only the 128-byte ICC header + tag table entries. No moxcms dependency needed. Handles ICC v2 (returns None), v4.4+ (finds tag), and iccMAX/v5 (same tag table format). Caps iteration at 200 tags for DoS protection.

## Test plan

- [x] 11 tests for `icc_extract_cicp` — valid extraction (sRGB, PQ, HLG), all error paths, malformed input, DoS cap
- [x] 20 tests for `SourceColor` — `color_authority` default/builder, `has_hdr_transfer()` from CICP (6 transfer functions), from ICC cicp tag (4 cases), priority/interaction (3 cases), edge cases (3 cases)
- [x] Existing tests unaffected (size_of assertion unchanged — fits in padding)