### PR TITLE
feat: lower MSRV to 1.88

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,12 +209,13 @@ jobs:
       - name: Patch path deps to git refs
         shell: bash
         run: |
+          # MSRV job needs zenpixels with lowered MSRV; update branch ref after merge to main
           sed \
-            -e 's|path = "\.\./zenpixels/zenpixels"|git = "https://github.com/imazen/zenpixels"|g' \
-            -e 's|path = "\.\./zenpixels/zenpixels-convert"|git = "https://github.com/imazen/zenpixels"|g' \
+            -e 's|path = "\.\./zenpixels/zenpixels"|git = "https://github.com/imazen/zenpixels", branch = "feat/lower-msrv"|g' \
+            -e 's|path = "\.\./zenpixels/zenpixels-convert"|git = "https://github.com/imazen/zenpixels", branch = "feat/lower-msrv"|g' \
             Cargo.toml > Cargo.toml.ci && \
             mv Cargo.toml.ci Cargo.toml
-          printf '\n[patch.crates-io]\nzenpixels = { git = "https://github.com/imazen/zenpixels" }\nzenpixels-convert = { git = "https://github.com/imazen/zenpixels" }\n' >> Cargo.toml
+          printf '\n[patch.crates-io]\nzenpixels = { git = "https://github.com/imazen/zenpixels", branch = "feat/lower-msrv" }\nzenpixels-convert = { git = "https://github.com/imazen/zenpixels", branch = "feat/lower-msrv" }\n' >> Cargo.toml
           rm -f Cargo.lock
 
       - name: Check MSRV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,13 +189,16 @@ jobs:
   # MSRV check
   # ==========================================================================
   msrv:
-    name: MSRV
+    name: MSRV (1.85)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
       - name: Configure git for private repos
         run: git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Install MSRV toolchain
+        run: rustup toolchain install 1.85.0 --no-self-update --profile minimal
 
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
   # MSRV check
   # ==========================================================================
   msrv:
-    name: MSRV (1.85)
+    name: MSRV (1.88)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -198,28 +198,21 @@ jobs:
         run: git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
 
       - name: Install MSRV toolchain
-        run: rustup toolchain install 1.85.0 --no-self-update --profile minimal
-
-      - name: Install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
+        run: rustup toolchain install 1.88.0 --no-self-update --profile minimal
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      - name: Patch path deps to git refs
+      - name: Patch zenpixels to git ref with lowered MSRV
         shell: bash
         run: |
-          # MSRV job needs zenpixels with lowered MSRV; update branch ref after merge to main
-          sed \
-            -e 's|path = "\.\./zenpixels/zenpixels"|git = "https://github.com/imazen/zenpixels", branch = "feat/lower-msrv"|g' \
-            -e 's|path = "\.\./zenpixels/zenpixels-convert"|git = "https://github.com/imazen/zenpixels", branch = "feat/lower-msrv"|g' \
-            Cargo.toml > Cargo.toml.ci && \
-            mv Cargo.toml.ci Cargo.toml
-          printf '\n[patch.crates-io]\nzenpixels = { git = "https://github.com/imazen/zenpixels", branch = "feat/lower-msrv" }\nzenpixels-convert = { git = "https://github.com/imazen/zenpixels", branch = "feat/lower-msrv" }\n' >> Cargo.toml
+          # zenpixels on crates.io still declares rust-version 1.93;
+          # patch to the branch with lowered MSRV until next publish.
+          printf '\n[patch.crates-io]\nzenpixels = { git = "https://github.com/imazen/zenpixels", branch = "feat/lower-msrv" }\n' >> Cargo.toml
           rm -f Cargo.lock
 
       - name: Check MSRV
-        run: cargo hack check --rust-version
+        run: cargo +1.88.0 check
 
   # ==========================================================================
   # Semver check (API compatibility)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,8 +207,8 @@ jobs:
         shell: bash
         run: |
           # zenpixels on crates.io still declares rust-version 1.93;
-          # patch to the branch with lowered MSRV until next publish.
-          printf '\n[patch.crates-io]\nzenpixels = { git = "https://github.com/imazen/zenpixels", branch = "feat/lower-msrv" }\n' >> Cargo.toml
+          # patch to git main (which has lowered MSRV) until next publish.
+          printf '\n[patch.crates-io]\nzenpixels = { git = "https://github.com/imazen/zenpixels" }\n' >> Cargo.toml
           rm -f Cargo.lock
 
       - name: Check MSRV

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zencodec"
 version = "0.1.13"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "Apache-2.0 OR MIT"
 description = "Shared traits and types for zen* image codecs"
 categories = ["multimedia::images"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zencodec"
 version = "0.1.13"
 edition = "2024"
-rust-version = "1.93"
+rust-version = "1.89"
 license = "Apache-2.0 OR MIT"
 description = "Shared traits and types for zen* image codecs"
 categories = ["multimedia::images"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zencodec"
 version = "0.1.13"
 edition = "2024"
-rust-version = "1.89"
+rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
 description = "Shared traits and types for zen* image codecs"
 categories = ["multimedia::images"]
@@ -15,8 +15,8 @@ name = "zencodec"
 
 [dependencies]
 zenpixels = { version = "0.2.2" }
-almost-enough = { version = "0.4.3", default-features = false, features = ["alloc"] }
-enough = "0.4.3"
+almost-enough = { version = "0.4.4", default-features = false, features = ["alloc"] }
+enough = "0.4.4"
 whereat = { version = "0.1.5"}
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- Bumps enough/almost-enough to 0.4.4 (their MSRV dropped to 1.85)
- Drops declared rust-version from 1.93 to 1.88 (let-chains floor)
- CI MSRV job patches zenpixels to git branch with lowered MSRV until next publish

## Blockers
- zencodec uses let-chains (stabilized 1.88) and trait upcasting (stabilized 1.86), so 1.88 is the floor
- zenpixels on crates.io still declares rust-version 1.93; CI patches to git ref

## Test plan
- [x] `cargo +1.88.0 check` passes locally with patched zenpixels
- [ ] CI MSRV job passes