### PR TITLE
feat(decode): gain-map render intent + reconstructs_hdr capability

### DIFF
--- a/docs/correctness-model.md
+++ b/docs/correctness-model.md
@@ -97,6 +97,26 @@ best-effort whole-channel gate, but they are not the retention control — they
 no-op on a codec that doesn't implement `with_policy`. For privacy, use a
 `MetadataPolicy`.
 
+## Gain-map HDR: signal on the buffer, envelope on the info
+
+A `PixelBuffer` is self-describing for the color **signal** — its descriptor
+carries transfer (PQ/HLG/linear), primaries, range, and bit depth, so the samples
+encode the HDR fully (PQ is absolute). It deliberately does **not** carry the
+luminance **envelope** (MaxCLL/MaxFALL, mastering display): the zenpixels color
+structs (`ColorContext`, `ColorOrigin`) are `Eq`, and `MasteringDisplay` is `f32`
+(not `Eq`), so the envelope lives on the non-`Eq` `ImageInfo`/`SourceColor` and
+`Metadata` instead — where it travels *alongside* the buffer, not inside it.
+
+So the contract for `GainMapRender::ReconstructHdr` (decode → native HDR): the
+codec returns the reconstructed buffer **and** populates
+`ImageInfo.source_color.{mastering_display, content_light_level}`. MaxCLL/MaxFALL
+are measured, so they are recomputed from the reconstructed pixels at encode time;
+the decoder carries the derived peak + the invariant mastering display. A full
+native-HDR encode is then `buffer (signal) + SourceColor (envelope)` — the encoder
+reads the envelope off `Metadata`. Skipping this silently drops the envelope on a
+gain-map → native-HDR transcode. (Gain-map → *gain-map* transcode is
+`GainMapRender::Components` and reconstructs nothing — no envelope step.)
+
 ## Verifying a codec: zencodec-testkit
 
 The contract above is only worth anything if codecs actually honor it. The

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -524,6 +524,7 @@ pub struct DecodeCapabilities {
     // Format capabilities
     hdr: bool,
     gain_map: bool,
+    reconstructs_hdr: bool,
     native_gray: bool,
     native_16bit: bool,
     native_f32: bool,
@@ -561,6 +562,7 @@ impl DecodeCapabilities {
             streaming: false,
             hdr: false,
             gain_map: false,
+            reconstructs_hdr: false,
             native_gray: false,
             native_16bit: false,
             native_f32: false,
@@ -624,6 +626,17 @@ impl DecodeCapabilities {
     /// Whether the codec supports gain map (HDR/SDR) extraction.
     pub const fn gain_map(&self) -> bool {
         self.gain_map
+    }
+    /// Whether the codec *reconstructs* HDR itself (applies the gain map), as
+    /// opposed to only extracting/surfacing it.
+    ///
+    /// Gates [`GainMapRender::ReconstructHdr`](crate::decode::GainMapRender::ReconstructHdr):
+    /// when `false`, a decoder asked to reconstruct surfaces the gain map as
+    /// [`Components`](crate::decode::GainMapRender::Components) (or reports
+    /// [`UnsupportedOperation`](crate::UnsupportedOperation)) and the apply math is
+    /// done one layer up — zencodec carries no HDR math.
+    pub const fn reconstructs_hdr(&self) -> bool {
+        self.reconstructs_hdr
     }
     /// Whether the codec supports grayscale natively.
     pub const fn native_gray(&self) -> bool {
@@ -758,6 +771,12 @@ impl DecodeCapabilities {
         self.gain_map = v;
         self
     }
+    /// Set whether the codec reconstructs HDR itself (applies the gain map).
+    /// See [`reconstructs_hdr`](Self::reconstructs_hdr).
+    pub const fn with_reconstructs_hdr(mut self, v: bool) -> Self {
+        self.reconstructs_hdr = v;
+        self
+    }
     /// Set whether native grayscale decoding is supported.
     pub const fn with_native_gray(mut self, v: bool) -> Self {
         self.native_gray = v;
@@ -818,6 +837,7 @@ impl fmt::Debug for DecodeCapabilities {
             .field("streaming", &self.streaming)
             .field("hdr", &self.hdr)
             .field("gain_map", &self.gain_map)
+            .field("reconstructs_hdr", &self.reconstructs_hdr)
             .field("native_gray", &self.native_gray)
             .field("native_16bit", &self.native_16bit)
             .field("native_f32", &self.native_f32)
@@ -918,6 +938,25 @@ mod tests {
         assert!(caps.animation());
         assert!(caps.enforces_max_input_bytes());
         assert_eq!(caps.threads_supported_range(), (1, 4));
+    }
+
+    #[test]
+    fn decode_gain_map_reconstruct_flags() {
+        // gain_map (extraction) and reconstructs_hdr (applies the gain map) are
+        // independent and both default false.
+        let base = DecodeCapabilities::new();
+        assert!(!base.gain_map());
+        assert!(!base.reconstructs_hdr());
+        // A codec that only extracts (surfaces Components) but doesn't reconstruct.
+        let extract_only = DecodeCapabilities::new().with_gain_map(true);
+        assert!(extract_only.gain_map());
+        assert!(!extract_only.reconstructs_hdr());
+        // A codec that reconstructs HDR internally.
+        let recon = DecodeCapabilities::new()
+            .with_gain_map(true)
+            .with_reconstructs_hdr(true);
+        assert!(recon.gain_map());
+        assert!(recon.reconstructs_hdr());
     }
 
     #[test]

--- a/src/gainmap.rs
+++ b/src/gainmap.rs
@@ -488,6 +488,60 @@ impl GainMapPresence {
     }
 }
 
+/// How a decoder should render a gain-map (HDR) image — the caller's intent for
+/// what `decode()` produces.
+///
+/// A gain-map file (AVIF `tmap`, JXL `jhgm`, JPEG UltraHDR) carries an SDR base
+/// image plus a gain map that reconstructs HDR on capable displays. This selects
+/// which rendition the decode output holds. Set it on the decode job via
+/// [`DecodeJob::with_gain_map_render`](crate::decode::DecodeJob::with_gain_map_render).
+///
+/// zencodec carries **no** HDR math: [`Components`](Self::Components) (extract +
+/// surface, no compositing) is the cheap codec-only path that a transcode wants,
+/// and [`ReconstructHdr`](Self::ReconstructHdr) (apply the gain map → HDR) is honored
+/// only by codecs that advertise
+/// [`DecodeCapabilities::reconstructs_hdr`](crate::decode::DecodeCapabilities::reconstructs_hdr).
+/// When a codec can't reconstruct, the apply math lives one layer up — apply the
+/// [`DecodedGainMap`] from `Components` via `ultrahdr-core`.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[non_exhaustive]
+pub enum GainMapRender {
+    /// Decode only the SDR base image; ignore the gain map. **Default** — an SDR
+    /// consumer gets a normal SDR image (and an SDR-sized buffer), no surprise HDR.
+    #[default]
+    BaseOnly,
+    /// Reconstruct HDR by applying the gain map to the base, rendered for the
+    /// display's HDR headroom. Output is an HDR pixel format (negotiated through the
+    /// normal ranked-descriptor preference). Honored only when the decoder's
+    /// [`reconstructs_hdr`](crate::decode::DecodeCapabilities::reconstructs_hdr)
+    /// capability is set; a decoder without it surfaces [`Components`](Self::Components)
+    /// or reports [`UnsupportedOperation`](crate::UnsupportedOperation) — never
+    /// silently SDR-labeled-as-HDR.
+    ///
+    /// **Envelope obligation.** The reconstructed [`PixelBuffer`](zenpixels::PixelBuffer)
+    /// carries the HDR *signal* (its descriptor's transfer/primaries/range), but **not**
+    /// the luminance *envelope*. A codec honoring this **must** populate the envelope on
+    /// the output [`ImageInfo`](crate::ImageInfo)'s [`SourceColor`](crate::decode::SourceColor) —
+    /// [`mastering_display`](crate::MasteringDisplay) (from the gain map's alternate-image
+    /// capacity) and [`content_light_level`](crate::ContentLightLevel) — so a downstream
+    /// full native-HDR encode is complete. MaxCLL/MaxFALL are *measured*, so the encoder
+    /// recomputes them from the actual reconstructed pixels; what the decoder carries is
+    /// the derived peak and the (invariant) mastering display. Without this the envelope
+    /// is silently lost on a gain-map → native-HDR transcode.
+    ReconstructHdr {
+        /// Target display HDR headroom (linear multiple of SDR white). `None` = the
+        /// gain map's encoded maximum (full reconstruction). Transcoding *to native HDR*
+        /// uses `None`; `Some(h)` renders for a specific display or HDR class. (Transcoding
+        /// to *another gain map* doesn't reconstruct at all — that's [`Components`](Self::Components).)
+        target_headroom: Option<f32>,
+    },
+    /// Decode the SDR base **and** surface the gain map (a [`DecodedGainMap`] in the
+    /// decode output's extras) without compositing — for transcoding or custom HDR
+    /// processing. Equivalent to the older
+    /// [`with_extract_gain_map(true)`](crate::decode::DecodeJob::with_extract_gain_map).
+    Components,
+}
+
 // =========================================================================
 // Gain map source (raw, pre-decode)
 // =========================================================================
@@ -2751,5 +2805,26 @@ mod tests {
         assert_eq!(Iso21496Format::JxlJhgm as u8, 2);
         assert_eq!(Iso21496Format::JpegApp2BodyWithUrn as u8, 3);
         assert_ne!(Iso21496Format::JpegApp2, Iso21496Format::JxlJhgm);
+    }
+
+    #[test]
+    fn gain_map_render_default_is_base_only() {
+        // The pit-of-success default: SDR base, no surprise HDR reconstruction.
+        assert_eq!(GainMapRender::default(), GainMapRender::BaseOnly);
+    }
+
+    #[test]
+    fn gain_map_render_reconstruct_carries_headroom() {
+        let full = GainMapRender::ReconstructHdr {
+            target_headroom: None,
+        };
+        let to_display = GainMapRender::ReconstructHdr {
+            target_headroom: Some(4.0),
+        };
+        assert_ne!(full, to_display);
+        assert_ne!(GainMapRender::Components, GainMapRender::BaseOnly);
+        // Copy + Eq so it threads cheaply through job builders.
+        let copied = to_display;
+        assert_eq!(copied, to_display);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ pub use exif::{Exif, ExifPolicy, Retention, TextEncoding};
 pub use extensions::Extensions;
 pub use format::{ImageFormat, ImageFormatDefinition, ImageFormatRegistry};
 pub use gainmap::{
-    GainMapChannel, GainMapDirection, GainMapInfo, GainMapParams, GainMapPresence,
+    GainMapChannel, GainMapDirection, GainMapInfo, GainMapParams, GainMapPresence, GainMapRender,
     ISO_21496_1_PRIMARY_APP2_BODY, ISO_21496_1_URN, Iso21496Format,
 };
 #[allow(deprecated)]
@@ -208,4 +208,7 @@ pub mod decode {
 
     // Shared types re-exported for convenience (commonly needed alongside decode)
     pub use crate::info::{EmbeddedMetadata, SourceColor};
+
+    // Gain-map decode intent + decoded payloads (the math stays in `ultrahdr-core`).
+    pub use crate::gainmap::{DecodedGainMap, GainMapRender};
 }

--- a/src/traits/decoding.rs
+++ b/src/traits/decoding.rs
@@ -177,7 +177,29 @@ pub trait DecodeJob<'a>: Sized {
     /// When true, codecs that support gain maps (AVIF tmap, JXL jhgm,
     /// JPEG UltraHDR) extract and attach gain map data to decode output
     /// extras. Typically set after probing reveals a gain map is present.
+    ///
+    /// This is the 2-way toggle; `with_extract_gain_map(true)` is equivalent to
+    /// [`with_gain_map_render`](Self::with_gain_map_render) with
+    /// [`GainMapRender::Components`](crate::decode::GainMapRender::Components). Prefer
+    /// `with_gain_map_render` when you also want the HDR-reconstruction intent.
     fn with_extract_gain_map(self, _extract: bool) -> Self {
+        self
+    }
+
+    /// Select how a gain-map (HDR) image is rendered — the caller's intent for what
+    /// `decode()` produces (SDR base, surfaced components, or reconstructed HDR).
+    ///
+    /// Default is a no-op (the codec's own default, normally
+    /// [`GainMapRender::BaseOnly`](crate::decode::GainMapRender)). Codecs that
+    /// support gain maps override this; check the codec's
+    /// [`DecodeCapabilities`](crate::decode::DecodeCapabilities) —
+    /// [`gain_map`](crate::decode::DecodeCapabilities::gain_map) for
+    /// `Components`/extraction, and
+    /// [`reconstructs_hdr`](crate::decode::DecodeCapabilities::reconstructs_hdr) for
+    /// [`ReconstructHdr`](crate::decode::GainMapRender::ReconstructHdr). zencodec
+    /// carries no HDR math: a codec that can't reconstruct surfaces `Components` (or
+    /// errors), and the apply happens one layer up (`ultrahdr-core`).
+    fn with_gain_map_render(self, _render: crate::GainMapRender) -> Self {
         self
     }
 

--- a/src/traits/dyn_decoding.rs
+++ b/src/traits/dyn_decoding.rs
@@ -223,6 +223,10 @@ pub trait DynDecodeJob<'a> {
     /// Opt in to supplementary gain map extraction.
     fn set_extract_gain_map(&mut self, _extract: bool) {}
 
+    /// Select how a gain-map (HDR) image is rendered. See
+    /// [`DecodeJob::with_gain_map_render`](crate::decode::DecodeJob::with_gain_map_render).
+    fn set_gain_map_render(&mut self, _render: crate::GainMapRender) {}
+
     /// Access codec-specific extensions for this job.
     ///
     /// Returns a reference to a `'static` extension type stored inside the
@@ -350,6 +354,10 @@ where
 
     fn set_extract_gain_map(&mut self, extract: bool) {
         self.try_apply(|job| job.with_extract_gain_map(extract));
+    }
+
+    fn set_gain_map_render(&mut self, render: crate::GainMapRender) {
+        self.try_apply(|job| job.with_gain_map_render(render));
     }
 
     fn extensions(&self) -> Option<&dyn Any> {


### PR DESCRIPTION
Decode-side contract for gain-map (HDR) images. zencodec carries **intent +
capability**; the HDR math stays in `ultrahdr-core` — no new deps, no dependency
cycle, and the lean `no_std` default is untouched.

## Adds
- **`GainMapRender`** (`gainmap`, re-exported at root + `decode`):
  `BaseOnly` (default), `ReconstructHdr { target_headroom: Option<f32> }`, `Components`
  — the caller's decode rendition intent.
- **`DecodeJob::with_gain_map_render(GainMapRender)`** — provided no-op default;
  dyn parity via **`set_gain_map_render`**.
- **`DecodeCapabilities::reconstructs_hdr()`** (+ `with_reconstructs_hdr`) — the honest
  signal for whether a codec *applies* the gain map itself vs only surfacing it. Gates
  `ReconstructHdr`.
- Re-export `DecodedGainMap` under `decode` (the `Components` payload).

## Contract
- `BaseOnly` = SDR base, ignore the gain map (the pit-of-success default — no surprise
  HDR buffers). `Components` = extract + surface a `DecodedGainMap` (what a transcode
  wants; equivalent to the existing `with_extract_gain_map(true)`). `ReconstructHdr` =
  apply → HDR, honored **only** by codecs that advertise `reconstructs_hdr`.
- **zencodec carries no HDR math.** A codec that can't reconstruct surfaces `Components`
  (or returns `UnsupportedOperation`) — never SDR-labeled-as-HDR. The apply lives one
  layer up (`ultrahdr-core::apply_gainmap` on the `Components` output), which keeps the
  `ultrahdr-core → zencodec` dependency direction intact (no cycle).
- The existing `with_extract_gain_map(bool)` / `set_extract_gain_map` stay (zenavif and
  the dyn layer use them); their docs now point at the richer `with_gain_map_render`.

## Scope
- **Decode-only**, per the agreed first step. Encode is intentionally untouched: native
  HDR already flows through the color-emit CICP path (PQ/HLG) + `Metadata`
  `content_light_level`/`mastering_display`; gain-map *production* (tonemap/compute) and
  the `with_gain_map` encode carrier are deferred.

## Verification
- Additive / non-breaking: `cargo-semver-checks` **196/196, "no semver update required"**.
- `no_std` + `wasm32-wasip1` clean; clippy `-D warnings` clean; `cargo fmt` clean.
- `cargo test --workspace` green, incl. new `gain_map_render_*` and
  `decode_gain_map_reconstruct_flags` tests.

Full design + phasing: `docs/gainmap-pipeline-scope-2026-06-08.md`.
