### PR TITLE
S1b (HDR #45): absolute-luminance anchor on Metadata + SourceColor

### DIFF
--- a/src/info.rs
+++ b/src/info.rs
@@ -196,7 +196,7 @@ pub enum ResolutionUnit {
     Unknown,
 }
 
-pub use zenpixels::{ContentLightLevel, MasteringDisplay};
+pub use zenpixels::{ContentLightLevel, DiffuseWhite, MasteringDisplay};
 
 /// Source color description from the image file.
 ///
@@ -239,6 +239,33 @@ pub struct SourceColor {
     pub content_light_level: Option<ContentLightLevel>,
     /// Mastering Display Color Volume (SMPTE ST 2086) for HDR content.
     pub mastering_display: Option<MasteringDisplay>,
+    /// Absolute-luminance anchor — the nits that a relative-linear sample
+    /// value of `1.0` represents (gain-map reconstruction yields 203, the
+    /// BT.2408 diffuse white).
+    ///
+    /// # Codec contract
+    ///
+    /// Codecs SHOULD populate this with `Some(value)` whenever they can
+    /// deliver a useful absolute-luminance anchor — including format-defined
+    /// implicit defaults that consumer code would otherwise have to
+    /// reconstruct independently. Consumer omission is worse than codec
+    /// double-signalling, so prefer to set the default at the source layer:
+    ///
+    /// - **Explicitly signalled** (JPEG XL `intensity_target`, OpenEXR
+    ///   `whiteLuminance`, HEIF `ndwt`, JXL gain-map `alternate_hdr_headroom`
+    ///   reconstruction): pass it through.
+    /// - **Spec-defined implicit default** (JPEG XL `intensity_target = 255`
+    ///   when the field is omitted, PQ container peak 10 000, HLG nominal
+    ///   peak per BT.2100 §6 + ambient): emit the format default so callers
+    ///   don't have to know per-codec rules.
+    /// - **Cross-format conventions** when the codec has a strong opinion:
+    ///   PNG with `cICP` transfer = PQ → emit `DiffuseWhite::BT2408` (203)
+    ///   as the cross-vendor relative-linear convention.
+    ///
+    /// `None` is reserved for genuinely-ambiguous cases (e.g. an unknown
+    /// transfer function paired with no metadata). When unsignalled, the
+    /// converter falls back to `DiffuseWhite::BT2408`.
+    pub diffuse_white: Option<DiffuseWhite>,
 }
 
 impl SourceColor {
@@ -333,7 +360,7 @@ impl SourceColor {
     /// returns the authoritative source without needing a separate
     /// authority parameter.
     pub fn to_color_context(&self) -> zenpixels::ColorContext {
-        match self.color_authority {
+        let base = match self.color_authority {
             ColorAuthority::Cicp if self.cicp.is_some() => {
                 zenpixels::ColorContext::from_cicp(self.cicp.unwrap())
             }
@@ -353,6 +380,12 @@ impl SourceColor {
                     zenpixels::ColorContext::default()
                 }
             }
+        };
+        // Carry the absolute-luminance anchor onto the pixel-side color context
+        // so the converter (e.g. `zenpixels_convert::hdr::quantize_to`) reads it.
+        match self.diffuse_white {
+            Some(white) => base.with_diffuse_white(white),
+            None => base,
         }
     }
 }
@@ -486,8 +519,9 @@ pub struct ImageInfo {
 }
 
 // ImageInfo contains Arc, Vec, trait objects — heavily pointer-dependent.
+// (SourceColor gained the diffuse_white Option<f32> anchor: 248 → 256 on 64-bit.)
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::size_of::<ImageInfo>() == 248);
+const _: () = assert!(core::mem::size_of::<ImageInfo>() == 256);
 
 impl ImageInfo {
     /// Create a new `ImageInfo` with the given dimensions and format.

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -35,7 +35,7 @@ use alloc::sync::Arc;
 
 use crate::Orientation;
 use crate::exif::{Exif, ExifPolicy, Retention};
-use crate::info::{Cicp, ContentLightLevel, MasteringDisplay};
+use crate::info::{Cicp, ContentLightLevel, DiffuseWhite, MasteringDisplay};
 use zenpixels::{ColorPrimaries, TransferFunction};
 
 /// Owned image metadata for encode/decode roundtrip.
@@ -58,14 +58,23 @@ pub struct Metadata {
     pub content_light_level: Option<ContentLightLevel>,
     /// Mastering Display Color Volume for HDR content.
     pub mastering_display: Option<MasteringDisplay>,
+    /// Absolute-luminance anchor — the nits that a relative-linear sample
+    /// value of `1.0` represents.
+    ///
+    /// Codec-side contract: same as [`SourceColor::diffuse_white`] — emit
+    /// `Some(value)` for explicit signals AND for format-defined implicit
+    /// defaults; reserve `None` for genuinely-ambiguous cases. See that
+    /// field for the per-format guidance.
+    pub diffuse_white: Option<DiffuseWhite>,
     /// EXIF orientation.
     pub orientation: Orientation,
 }
 
 // Metadata contains 3× Option<Arc<[u8]>> (fat pointers), so size varies by
 // pointer width. Catch unexpected growth from new fields or alignment changes.
+// (The diffuse_white Option<f32> anchor grew this 104 → 112 on 64-bit.)
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::size_of::<Metadata>() == 104);
+const _: () = assert!(core::mem::size_of::<Metadata>() == 112);
 
 impl Metadata {
     /// Create empty metadata.
@@ -156,6 +165,24 @@ impl Metadata {
     /// Set the Content Light Level Info.
     pub fn with_content_light_level(mut self, clli: ContentLightLevel) -> Self {
         self.content_light_level = Some(clli);
+        self
+    }
+
+    /// Set the absolute-luminance anchor (the nits of relative-linear `1.0`).
+    pub fn with_diffuse_white(mut self, white: DiffuseWhite) -> Self {
+        self.diffuse_white = Some(white);
+        self
+    }
+
+    /// Clear the absolute-luminance anchor — drop back to "unsignalled" so a
+    /// downstream re-encoder knows there is no anchor to emit, or so the
+    /// converter falls through to its `DiffuseWhite::BT2408` default.
+    ///
+    /// Needed because `Metadata` is `#[non_exhaustive]`: callers can't reach
+    /// in with a struct literal to set the field back to `None`. Pairs with
+    /// [`with_diffuse_white`](Self::with_diffuse_white).
+    pub fn clear_diffuse_white(mut self) -> Self {
+        self.diffuse_white = None;
         self
     }
 
@@ -555,6 +582,7 @@ impl From<&crate::ImageInfo> for Metadata {
             cicp: info.source_color.cicp,
             content_light_level: info.source_color.content_light_level,
             mastering_display: info.source_color.mastering_display,
+            diffuse_white: info.source_color.diffuse_white,
             orientation: info.orientation,
         }
     }

--- a/src/output.rs
+++ b/src/output.rs
@@ -192,8 +192,10 @@ pub struct DecodeOutput {
     extensions: Extensions,
 }
 
+// (Carries ImageInfo, which gained the SourceColor diffuse_white anchor:
+// 352 → 360 on 64-bit.)
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(core::mem::size_of::<DecodeOutput>() == 352);
+const _: () = assert!(core::mem::size_of::<DecodeOutput>() == 360);
 
 impl DecodeOutput {
     /// Create a new decode output from a [`PixelBuffer`].


### PR DESCRIPTION
**S1b of the M×N HDR pipeline epic** (imazen/zenpixels#45). Carries the absolute-luminance anchor across the codec boundary.

## Change (additive — both structs already `#[non_exhaustive]`)
- `SourceColor` + `Metadata` gain `diffuse_white: Option<DiffuseWhite>` + a `Metadata::with_diffuse_white` builder; `DiffuseWhite` re-exported from zencodec.
- `Metadata::clear_diffuse_white` lets callers drop the anchor back to `None` (sealed struct → no struct-literal reset path).
- `Metadata::from(ImageInfo)` propagates the anchor.
- **`SourceColor::to_color_context` threads the anchor onto the pixel-side `zenpixels::ColorContext`** — so a decoded buffer carries it and the converter (`zenpixels_convert::hdr::quantize_to`) reads it.

## Codec-side contract (locked in via docstring)
Codecs SHOULD emit `Some(value)` whenever they can deliver an absolute-luminance anchor, including **format-defined implicit defaults** — JPEG XL `intensity_target = 255` when omitted, PQ container peak 10 000, HLG nominal per BT.2100 §6, PNG cICP+PQ → BT.2408 (203). `None` is reserved for genuinely-ambiguous cases. Reason: consumer omission is worse than codec double-signalling. Consumer omission → `DiffuseWhite::BT2408` fallback in `zenpixels_convert::hdr::quantize_setup`.

## Verification
- Builds against `zenpixels 0.2.14` (published on crates.io).
- **508 lib tests pass.**
- `cargo clippy --lib --all-targets -- -D warnings` clean.
- `cargo fmt` clean.
- Size asserts bumped for the `Option<f32>` anchor: `Metadata` 104→112, `ImageInfo` 248→256, `DecodeOutput` 352→360 (const-assert-verified).

## Rebased onto current main
The PR was rebased onto `da98619b` (0.1.23 release) so the ride-along empty-`ColorContext` fix that also shipped independently in 0.1.23 is dropped here. No conflicts now; `mergeable: MERGEABLE`.