### PR TITLE
docs(zencodec): align max-pixels doc examples + stale comment to the 120MP default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ All notable changes to zencodec are documented here.
 - `ResourceLimits::for_untrusted_input()` raises `max_pixels` from 100 MP to
   120 MP so common ~108 MP camera photos pass the recommended untrusted-input
   policy (`max_total_pixels` stays 200 MP). No API change.
+- Doc cleanup to match that 120 MP default: the `ResourceLimits` example now
+  uses `with_max_pixels(120_000_000)`, and the `for_untrusted_input()` doc
+  comment now states the `max_pixels` cap as 120 MP (it still claimed 100 MP).
+  Docs only — no behavior change.
 
 ### Added
 

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -225,7 +225,7 @@ impl ThreadingPolicy {
 /// use zencodec::ResourceLimits;
 ///
 /// let limits = ResourceLimits::none()
-///     .with_max_pixels(100_000_000)
+///     .with_max_pixels(120_000_000) // admits ~108 MP photos
 ///     .with_max_memory(512 * 1024 * 1024);
 /// ```
 ///
@@ -312,7 +312,7 @@ impl ResourceLimits {
     /// not explicitly tuned by the caller.
     ///
     /// Caps applied (chosen conservatively for typical web image workloads):
-    /// - `max_pixels`: 100 MP per frame (covers e.g. 12000 × 8000 stills)
+    /// - `max_pixels`: 120 MP per frame (admits ~108 MP photos, e.g. 12000 × 9000)
     /// - `max_total_pixels`: 200 MP across all frames of an animation
     /// - `max_width` / `max_height`: 16384 each (typical decoder hardware ceiling)
     /// - `max_memory_bytes`: 1 GiB


### PR DESCRIPTION
## Summary

`ResourceLimits::for_untrusted_input()` already defaults `max_pixels` to `120_000_000` (raised in a prior change), but two docs still showed the old 100 MP figure, which is misleading. This is a **docs-only** cleanup — no API or behavior change.

## Changes (`src/limits.rs`)
- The `ResourceLimits` `# Example` (the headline example): `with_max_pixels(100_000_000)` → `with_max_pixels(120_000_000) // admits ~108 MP photos`.
- The `for_untrusted_input()` doc comment: `- max_pixels: 100 MP per frame (covers e.g. 12000 × 8000 stills)` → `120 MP per frame (admits ~108 MP photos, e.g. 12000 × 9000)`, matching the actual `Some(120_000_000)` default.

`CHANGELOG.md`: appended a note under the existing `### Changed` 120 MP entry.

## Deliberately left unchanged
- The `Some(120_000_000)` default itself (already correct).
- Arbitrary `100_000_000` **test inputs** that exercise the limit machinery (`with_max_total_pixels(100_000_000)` cases + the `exceeds limit 100000000` error-string test) — these are arbitrary values, not default claims.
- A test comment at the `for_untrusted_input_rejects_oversized_image` test that says "far above the 100 MP per-frame cap" — it's a code comment inside a test (not a doc example), its assertion stays true (900 MP > 120 MP, and width trips first), and the sibling line already reads "120 MP cap". Left as-is to keep scope to docs; flagging for awareness.

## Notes
- No `cargo` run locally (machine-safety); CI is the gate.
- Built in an isolated worktree off `main@origin`; the repo's concurrent HDR working copy was not touched.