### PR TITLE
feat(error): unified error taxonomy + CodecError envelope (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,112 @@ All notable changes to zencodec are documented here.
   utility that consults `ColorProfileSource` and `HdrPolicy` together
   rather than inspecting raw CICP/ICC fields.
 
+### Added
+- **Unified error taxonomy: `ErrorCategory` enum + `CategorizedError` trait** —
+  a codec-agnostic way to classify any codec error for routing (HTTP status,
+  retry, logging) without naming the concrete enum (zencodec#99, superseding the
+  cancellation-only sketch). `ErrorCategory` (`#[non_exhaustive]`, `Copy`):
+  `MalformedImage`, `UnexpectedEof`, `UnsupportedImageType`,
+  `UnsupportedImageFeature`, `UnsupportedPixelFormat`, `UnsupportedOperation`,
+  `CmsRequired`, `PolicyRejected`, `Cancelled`, `TimedOut`,
+  `LimitsExceeded(LimitKind)`, `OutOfMemory`, `Io`, `InvalidParameters`,
+  `InvalidBuffer`, `InvalidState`, `Internal` — the set distilled from an
+  inventory of every zen codec's error enum (the "unsupported" axis splits into
+  type / image-feature / pixel-format-negotiation / API-operation; `CmsRequired`
+  covers e.g. zenwebp's ICC-synthesis-unavailable; `PolicyRejected` covers valid
+  input a configured policy declined, e.g. zenjxl's progressive-rejected;
+  `InvalidBuffer` is a wrong-geometry pixel buffer and `InvalidState` is API
+  misuse / wrong-sequence). `CategorizedError: Any { fn codec_name(&self) ->
+  Option<&'static str>; fn category(&self) -> ErrorCategory }` is **opt-in** (not
+  blanket-impl'd, not added to the `Error` bound), so adopting it is additive and
+  back-compatible. The `Any` supertrait keeps a `dyn CategorizedError` downcastable
+  (both methods take `&self`, so the trait is dyn-compatible); `codec_name()` is
+  required, returning `None` for the non-codec cause types. A blanket impl forwards
+  through `whereat::At<E>` so a located error keeps its category;
+  zencodec's own cause types implement it (`LimitExceeded` →
+  `LimitsExceeded(kind)`, `UnsupportedOperation` → `UnsupportedOperation` /
+  `UnsupportedPixelFormat`, `enough::StopReason` → `Cancelled`/`TimedOut`), making
+  a codec's mapping a one-line delegation per arm.
+  Adds `LimitKind` (the value-free discriminant of `LimitExceeded`, via
+  `LimitExceeded::kind()`). No new dependencies. The testkit `reference` codec
+  adopts the trait; `reference_cancellation_is_classifiable` proves end-to-end
+  classification through a real cancelled operation. The category set is backed
+  by a per-codec error inventory + right-sizing analysis in
+  `docs/error-taxonomy-inventory.md` (with `docs/error-types-ecosystem.md`
+  surveying the surrounding crates).
+- **`CodecError` envelope + `CodecErrorExt::{codec_error, error_category}`** — the
+  carrier that makes a category (and the originating codec) survive **type
+  erasure**, the gap `CategorizedError` alone can't close (after erasure you hold a
+  `dyn Error`, not a `dyn CategorizedError`). A codec returns it as
+  `whereat::At<CodecError>` — a single *concrete* type, so a consumer recovers the
+  category **and** the codec name from any `Box<dyn Error>` / `anyhow::Error` /
+  mapped wrapper.
+  - **Register-fittable.** `CodecError` is a one-word handle (`Box<Repr>`), so
+    `At<CodecError>` is two words (16 bytes) and `Result<_, At<CodecError>>` is two
+    words too (the box pointer's niche absorbs the discriminant) — returned in
+    registers, not spilled to the stack. The box is what makes that possible: the
+    detail is a *fat* `Box<dyn Error>` (16 bytes alone), so an unboxed envelope
+    would exceed the 16-byte ABI threshold and spill regardless of how thin the
+    other fields are. Trade: one cold-path alloc per error; `new` is no longer
+    `const`. A word-relative `error_types_stay_small` test guards it.
+  - Constructors: `new(codec, category)` (complete error, **no detail**),
+    `from_native(detail)` (bare envelope; reads *both* the category and the codec
+    name from the detail's `CategorizedError`), `of(located: At<E>) -> At<CodecError>`
+    (the located form — maps the inner error via whereat's trace-preserving
+    `map_error`, keeping the `At` on the outside), `from_parts(codec, category,
+    boxed)`, and `with_codec(self, Option<&'static str>)` — a builder to stamp or
+    clear the codec name on an envelope built without one. Accessors `category()` /
+    `codec() -> Option<&'static str>` +
+    `detail() -> Option<&dyn Error>`. `Display` = `"{codec}: {detail-or-category}"`
+    (adds a `Display` impl on `ErrorCategory`); `source()` = detail when present.
+  - **`of` forces location at the type level**: it takes an already-located `At<E>`,
+    so a codec that skipped whereat can't call it — the omission is a compile error,
+    not a silently trace-less error. (`from_native` + whereat's
+    `map_err_at(CodecError::from_native)` converts a bare `Result<_, E>` in one step.)
+  - The codec name lives on the trait as the **required** `codec_name(&self) ->
+    Option<&'static str>` method — no default, so every implementor answers it; the
+    cause types return `None`. It is a `&self` method rather than an associated const
+    precisely so the trait stays **dyn-compatible**: with the new `Any` supertrait a
+    `dyn CategorizedError` can be formed *and* downcast to its concrete type (an
+    associated const forbids the trait object outright). `from_native`/`of`
+    `debug_assert` the name is `Some`, so building an envelope from a bare shared
+    cause type (e.g. `UnsupportedOperation`) fails loudly in dev; wrap such causes in
+    your codec's error type first.
+  - **`ErrorCategory::Io(CodecIoKind)`** carries a `std::io::ErrorKind` under the new
+    opt-in `std` feature, empty under `no_std` (stable variant shape either way, so
+    matching `Io(_)` is portable), anticipating a future `core::io::ErrorKind`.
+  - `CodecErrorExt::codec_error() -> Option<&CodecError>` recovers the envelope by
+    downcast (`At<CodecError>` or a bare `CodecError`); `error_category()` is the
+    shortcut. Both defaulted (additive). Recovery also tolerates a single
+    consumer-applied `Box` layer (`Box<At<CodecError>>` / `At<Box<CodecError>>` /
+    `Box<CodecError>`).
+  - Adoption is one impl per codec — `impl From<MyError> for At<CodecError>` (body
+    `CodecError::of(e.start_at())`, with `fn codec_name(&self) { Some("mycodec") }`
+    on the error's `CategorizedError` impl) — after which `?` auto-wraps existing
+    fallible internals; reject stubs use `Unsupported<At<CodecError>>`.
+  - The testkit `minimal` codec is converted to this pattern;
+    `minimal_envelope_category_survives_dyn_erasure` proves the category **and the
+    codec name** are recovered after the dyn shim erases the error to `BoxedError`
+    (and that the native-enum `reference` path returns `None` once erased — the
+    contrast that motivates the envelope).
+  - All additive vs 0.1.25 (which has neither type) — these are new items; a
+    `cargo-semver-checks` run gates the eventual release (zencodec#99, zencodec#103).
+- **`StreamOffset(pub u64)`** — a shared, downcast-able newtype for the one piece
+  of context worth carrying generically: *where in the encoded input* a decode
+  failed. A codec attaches it to its `At<CodecError>` trace with `.at_data(||
+  StreamOffset(pos))` (rather than a per-locus `CodecError` field); a generic
+  consumer recovers it via `err.contexts().find_map(|c|
+  c.downcast_ref::<StreamOffset>())` — even after erasure to `Box<dyn Error>` — with
+  no codec-specific type named. Per-variant detail (dims, expected/actual, table
+  indices) stays in the native error; richer loci (marker / box fourcc / NAL /
+  frame index) ride the same `at_data` channel, with only the byte offset
+  standardized as a type today. Additive.
+- **Re-export `whereat::{At, ErrorAtExt, ResultAtExt}`** (and `pub use whereat;`) at
+  the crate root, so a codec can name `zencodec::At<zencodec::CodecError>` — the
+  recommended `Error` type — and reach `start_at()` / `.at()` without a direct
+  `whereat` dependency. No new coupling: `At` was already in the public API via the
+  blanket `impl CategorizedError for At<E>`. Additive.
+
 ### Changed
 - Docs: README overhauled to the shared zen\* README conventions — CI badge drops the
   `branch=` param and gains a `label`, an MSRV (1.88) badge is added, a `## Quick start`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,12 @@ include = [
 [lib]
 name = "zencodec"
 
+[features]
+# Opt-in: lets `ErrorCategory::Io`'s `CodecIoKind` carry a `std::io::ErrorKind`.
+# The crate is `#![no_std]` by default; this only pulls in `std` for that one
+# payload. When `core::io::ErrorKind` stabilizes this feature becomes a no-op.
+std = []
+
 [dependencies]
 # Published manifest uses crates.io versions (CI + `cargo publish` build the
 # real artifact). Local development builds against the in-tree zen sources via

--- a/README.md
+++ b/README.md
@@ -186,23 +186,69 @@ the `max_memory_bytes` cap so a codec that under-reports still can't over-alloca
 
 ### Classifying a codec's error for an HTTP response
 
-Each codec keeps its OWN opaque error type (there is no shared `CodecError`).
-Classify one without naming the concrete enum, via `CodecErrorExt`:
+A codec surfaces errors one of two ways; both let you route on a coarse
+`ErrorCategory` instead of naming the concrete enum:
+
+- **Native enum + `CategorizedError`.** The codec keeps its own error type and
+  maps every variant to one category. `e.category()` classifies it on the typed
+  path, and a located `whereat::At<E>` keeps the inner error's category (the impl
+  forwards through `At`).
+- **The shared `CodecError` envelope.** The codec sets `type Error =
+  whereat::At<CodecError>`. Because that is a single *concrete* type, the category
+  — and the originating **codec name** (`"zenjpeg"`, so you can tell codecs apart)
+  — survive **type erasure**: after dyn dispatch hands back a `Box<dyn Error>` — or
+  you map into `anyhow` — `e.error_category()` / `e.codec_error()` recover them by
+  downcast (`None` only when the error isn't from a zen codec). A native enum can't
+  be recovered once erased — the erased value is a `dyn Error`, not a
+  `dyn CategorizedError` — so the envelope is what a codec-agnostic pipeline reaches
+  for. `CodecError` can also be used with no detail at all
+  (`CodecError::new(Some("zenpng"), ErrorCategory::MalformedImage)`) by a codec that
+  has no error enum of its own. `At` is re-exported
+  (`zencodec::At<zencodec::CodecError>`), so adopting it needs no direct `whereat`
+  dependency.
 
 ```rust,ignore
-match config.job().decoder(Cow::Borrowed(bytes), &[]) {
-    Ok(_decoder) => { /* _decoder.decode()? */ }
-    Err(e) => {
-        if let Some(limit) = e.limit_exceeded() {
-            eprintln!("resource limit: {limit}"); // -> HTTP 413
-        } else if e.unsupported_operation().is_some() {
-            eprintln!("unsupported"); // -> HTTP 415
-        } else {
-            eprintln!("malformed input: {e}"); // -> HTTP 400
-        }
-    }
-}
+use zencodec::{CategorizedError, CodecErrorExt, ErrorCategory};
+
+// Typed path shown here via `category()`; on a `Box<dyn Error>` from dyn dispatch
+// use `e.error_category()` and match `Some(..)` / `None` instead.
+let http = match config.job().with_stop(token).decoder(Cow::Borrowed(bytes), &[]) {
+    Ok(_decoder) => { /* _decoder.decode()? */ 200 }
+    Err(e) => match e.category() {
+        ErrorCategory::Cancelled            => 499, // client went away
+        ErrorCategory::TimedOut             => 504,
+        ErrorCategory::LimitsExceeded(_)    => 413,
+        ErrorCategory::UnsupportedImageType
+        | ErrorCategory::UnsupportedImageFeature
+        | ErrorCategory::UnsupportedPixelFormat
+        | ErrorCategory::UnsupportedOperation
+        | ErrorCategory::CmsRequired        => 415, // can't process this input/request
+        ErrorCategory::PolicyRejected       => 422, // valid, but a policy declined it
+        ErrorCategory::MalformedImage
+        | ErrorCategory::UnexpectedEof
+        | ErrorCategory::InvalidParameters
+        | ErrorCategory::InvalidBuffer      => 400, // the bytes / request are bad
+        ErrorCategory::OutOfMemory
+        | ErrorCategory::Io(_)
+        | ErrorCategory::InvalidState
+        | ErrorCategory::Internal           => 500, // server-side: resource, IO, bug, misuse
+        _ => 500, // ErrorCategory is #[non_exhaustive]
+    },
+};
 ```
+
+`ErrorCategory` is the coarse routing axis (it's `Copy`, and
+`LimitsExceeded(LimitKind)` even tells you *which* cap). When you need more
+detail than the category, the typed extractors on `CodecErrorExt` recover the
+cause from the `source()` chain — `e.limit_exceeded()` for the exact limit values,
+`e.unsupported_operation()` for which operation, or `e.find_cause::<T>()` for a
+codec-specific type. `category()` is available once a codec implements
+`CategorizedError`; the zencodec cause types (`LimitExceeded`,
+`UnsupportedOperation`, `enough::StopReason`) implement it, so a codec's mapping
+is usually a one-line delegation per variant. `CodecErrorExt::error_category()`
+is the same answer recovered through erasure — it works on any `Box<dyn Error>`
+holding a `CodecError` (bare or `At`-wrapped), so the routing survives dyn
+dispatch and `anyhow`.
 
 ## Controlling decode parallelism
 

--- a/docs/error-taxonomy-inventory.md
+++ b/docs/error-taxonomy-inventory.md
@@ -1,0 +1,258 @@
+# Codec error inventory → `ErrorCategory` mapping
+
+Point-in-time reference (snapshot **2026-06-24**) backing the
+[`ErrorCategory`](../src/error.rs) / `CategorizedError` design (issue #99). It
+records the **actual error enum of every zen image codec**, maps every variant
+to a category, and evaluates whether the 17-variant set is right-sized.
+
+Other repos' error enums drift — re-run the inventory (grep `pub enum .*Error`
++ the `#[error(...)]` lines under each codec's `src/`) if validating afresh.
+
+## The categories (17)
+
+`MalformedImage`, `UnexpectedEof`, `UnsupportedImageType`,
+`UnsupportedImageFeature`, `UnsupportedPixelFormat`, `UnsupportedOperation`,
+`CmsRequired`, `PolicyRejected`, `Cancelled`, `TimedOut`,
+`LimitsExceeded(LimitKind)`, `OutOfMemory`, `Io`, `InvalidParameters`,
+`InvalidBuffer`, `InvalidState`, `Internal`.
+
+## Carrying the category
+
+The mapping below says *which* category each variant is. *How* a codec carries
+it to a consumer is a separate choice:
+
+- **Native enum + `CategorizedError`** — `type Error = MyError`. The category is
+  reachable on the typed path (`e.category()` / forwarded through `At<MyError>`),
+  but **not** after the error is erased to `Box<dyn Error>` (the erased value is a
+  `dyn Error`, not a `dyn CategorizedError`).
+- **The `CodecError` envelope** — `type Error = whereat::At<CodecError>`. Since
+  that is one concrete type, the category survives erasure: a consumer recovers
+  it from any `Box<dyn Error>` / `anyhow` via `CodecErrorExt::error_category()`.
+  Recommended for codecs driven through dyn dispatch. The per-codec mapping in
+  this doc is unchanged either way — it just feeds `CodecError::from_native`/`of`
+  instead of being read off the typed enum. See [`spec.md`](spec.md) (`CodecError`) for the
+  one-impl adoption recipe.
+
+---
+
+## Per-codec error enums (verbatim variant inventory)
+
+### zenjpeg — `Error(pub whereat::At<ErrorKind>)`
+`zenjpeg/zenjpeg/src/` (nested workspace). Public `Error` newtypes `At<ErrorKind>`;
+there are layered kinds (top-level `error.rs`, plus `encoder/error.rs`,
+`decoder/error.rs`, `recompress/error.rs`). Distinct variants across them:
+- `InvalidDimensions{w,h,reason}`, `InvalidColorFormat`,
+  `InvalidJpegData`, `TruncatedData`, `InvalidMarker`, `InvalidHuffmanTable`,
+  `InvalidQuantTable`, `DecodeError`, `InvalidScanScript` → **MalformedImage** /
+  (truncation → **UnexpectedEof**)
+- `UnsupportedFeature{feature}` → **UnsupportedImageFeature**
+- `UnsupportedPixelFormat{format}` → **UnsupportedPixelFormat**
+- `ImageTooLarge{pixels,limit}`, `TooManyScans` → **LimitsExceeded**
+- `AllocationFailed{bytes,context}` → **OutOfMemory**
+- `SizeOverflow{context}`, `InternalError{reason}`, `Internal{reason}` → **Internal**
+- `IoError{reason}` → **Io**
+- `IccError(String)` / `Icc(String)` → **CmsRequired**
+- `InvalidBufferSize{expected,actual}`, `StrideTooSmall{width,stride}` → **InvalidBuffer**
+- `TooManyRows`, `IncompleteImage` → **InvalidState**
+- `InvalidQuality`, `InvalidConfig`, `TargetOutOfRange` → **InvalidParameters**
+- `Cancelled(enough::StopReason)` → **Cancelled** / **TimedOut**
+
+### zenpng — `PngError` (`At<PngError>` at the boundary)
+- `Decode(String)` → **MalformedImage**
+- `InvalidInput(String)` → **MalformedImage** / **InvalidParameters** (context-dependent; also carries `UnsupportedOperation::PixelFormat` → **UnsupportedPixelFormat**)
+- `LimitExceeded(String)` → **LimitsExceeded**
+- `Stopped(enough::StopReason)` → **Cancelled**/**TimedOut**
+- `Quantize(#[from] zenquant::QuantizeError)` → **Internal**
+- (`ProbeError`: `TooShort`/`Truncated` → **UnexpectedEof**, `NotPng` → **UnsupportedImageType**)
+
+### zenwebp — `DecodeError` / `EncodeError` / `MuxError` / `ValidationError`
+- decode malformed set (`RiffSignatureInvalid`, `WebpSignatureInvalid`, `ChunkMissing`, `ChunkHeaderInvalid`, `InvalidAlphaPreprocessing`, `InvalidCompressionMethod`, `AlphaChunkSizeMismatch`, `FrameOutsideImage`, `LosslessSignatureInvalid`, `VersionNumberInvalid`, `InvalidColorCacheBits`, `HuffmanError`, `BitStreamError`, `TransformError`, `Vp8MagicInvalid`, `ColorSpaceInvalid`, `*PredictionModeInvalid`, `InconsistentImageSizes`, `InvalidChunkSize`) → **MalformedImage**
+- `NotEnoughInitData` → **UnexpectedEof**
+- `UnsupportedFeature(String)` → **UnsupportedImageFeature**
+- `UnsupportedOperation(#[from] zencodec::UnsupportedOperation)` → **UnsupportedOperation** (+`PixelFormat` arm → **UnsupportedPixelFormat**)
+- `ImageTooLarge`, `MemoryLimitExceeded`, `LimitExceeded`, `Partition0Overflow` → **LimitsExceeded**
+- `Cancelled(enough::StopReason)` → **Cancelled**/**TimedOut**
+- `IoError(#[from] std::io::Error)` → **Io**
+- `IccSynthesisUnavailable(String)` → **CmsRequired**
+- `InvalidBufferSize` → **InvalidBuffer**
+- `InvalidParameter`, `InvalidDimensions`, `TargetZensimUnsupportedLayout`, all of `ValidationError::*OutOfRange` → **InvalidParameters**
+- `NoMoreFrames` → animation-iteration end (**UnexpectedEof**, control-flow)
+
+### zengif — `GifError`
+- `InvalidHeader`, `InvalidScreenDescriptor`, `InvalidFrameBounds`, `ZeroDimensionFrame`, `MissingPalette`, `InvalidDisposalMethod`, `MalformedLzw`, `InvalidMinCodeSize`, `FrameDimensionMismatch`, `GifCrate` → **MalformedImage**
+- `UnsupportedVersion` → **UnsupportedImageType**
+- `UnexpectedEof` → **UnexpectedEof**
+- `DimensionsTooLarge`, `TotalPixelsTooLarge`, `TooManyFrames`, `FileTooLarge`, `MemoryLimitExceeded`, `DecompressionRatioExceeded`, `AnimationTooLong`, `OutputTooLarge` → **LimitsExceeded**
+- `AllocationFailed` → **OutOfMemory**
+- `Io` → **Io**
+- `Cancelled` → **Cancelled**
+- `UnsupportedOperation(zencodec::UnsupportedOperation)` → **UnsupportedOperation**
+- `InvalidEncoderState` → **InvalidState**
+- `QuantizationFailed` → **Internal**
+
+### zenavif — `Error`
+- `Parse(#[from] zenavif_parse::Error)` → **MalformedImage**
+- `Unsupported(&str)` → **UnsupportedImageFeature**
+- `ImageTooLarge`, `ResourceLimit(String)` → **LimitsExceeded**
+- `OutOfMemory` → **OutOfMemory**
+- `Cancelled(StopReason)` → **Cancelled**/**TimedOut**
+- `UnsupportedOperation(#[from] zencodec::UnsupportedOperation)` → **UnsupportedOperation**
+- `Decode{code,msg}`, `Encode(String)`, `ColorConversion(#[from] yuv::YuvError)` → **Internal**
+
+### zenjxl — `JxlError`
+- `Decode(#[from] jxl::api::Error)` → **MalformedImage**
+- `InvalidInput(String)` → **MalformedImage**/**InvalidParameters**
+- `ProgressiveRejected` → **PolicyRejected** (rejected by decode policy)
+- `LimitExceeded(String)` → **LimitsExceeded**
+- `Cancelled(enough::StopReason)` → **Cancelled**/**TimedOut**
+- `UnsupportedOperation(#[from] zencodec::UnsupportedOperation)` → **UnsupportedOperation**
+- `Sink(zencodec::decode::SinkError)` → **Io**
+- `Encode(#[from] jxl_encoder::EncodeError)` → **Internal**
+
+### zenbitmaps — `BitmapError` (`At<BitmapError>` at the boundary)
+- `InvalidHeader`, `InvalidData` → **MalformedImage**
+- `UnrecognizedFormat` → **UnsupportedImageType**
+- `UnsupportedVariant(String)` → **UnsupportedImageType** (or **UnsupportedImageFeature**)
+- `UnexpectedEof` → **UnexpectedEof**
+- `DimensionsTooLarge`, `LimitExceeded` → **LimitsExceeded**
+- `BufferTooSmall{needed,actual}`, `LayoutMismatch{expected,actual}` → **InvalidBuffer**
+- `Cancelled(StopReason)` → **Cancelled**/**TimedOut**
+- `UnsupportedOperation(#[from] zencodec::UnsupportedOperation)` → **UnsupportedOperation**
+
+### heic — `HeicError` (+ `HevcError`, `ProbeError`); `type Error = At<HeicError>`
+- `InvalidContainer`, `InvalidData`, `InvalidBitstream`, `InvalidNalUnit`, `MissingParameterSet`, `InvalidParameterSet`, `CabacError`, `ProbeError::{InvalidFormat,Corrupt}` → **MalformedImage**
+- `ProbeError::NeedMoreData` → **UnexpectedEof**
+- `UnsupportedCodec`, `UnsupportedProfile` → **UnsupportedImageType**
+- `Unsupported(&str)` → **UnsupportedImageFeature**
+- `BufferTooSmall` → **InvalidBuffer**
+- `LimitExceeded`, `DimensionOverflow` → **LimitsExceeded**
+- `OutOfMemory`, `AllocationFailed` → **OutOfMemory**
+- `Cancelled(StopReason)` → **Cancelled**/**TimedOut**
+- `Sink(Box<dyn Error>)` → **Io**
+- `HevcDecode`, `DecodingError`, `NoPrimaryImage`, `NoBackendSelected`, `AllBackendsFailed` → **Internal**
+
+### zentiff — not checked out locally
+Per the crate index it wraps `image-tiff`; its error type would forward
+`image_tiff`'s decode errors (→ **MalformedImage** / **UnsupportedImageFeature**)
+plus the standard `UnsupportedOperation` / `LimitsExceeded` / `Cancelled` arms.
+Confirm when adopting.
+
+---
+
+## Design evaluation — is the 17-set right-sized?
+
+**Coverage.** Every variant across all eight inventoried codecs maps to exactly
+one category. No variant is left unclassifiable.
+
+**No dead categories.** Each category is backed by multiple real variants across
+multiple codecs:
+
+| category | representative backers |
+|---|---|
+| MalformedImage | every decoder (dozens of variants) |
+| UnexpectedEof | zengif, zenbitmaps, zenjpeg, zenwebp, heic |
+| UnsupportedImageType | zenpng, zenwebp, zengif, zenbitmaps, heic |
+| UnsupportedImageFeature | **zenjpeg (`UnsupportedFeature`)**, zenwebp, zenavif, heic |
+| UnsupportedPixelFormat | **zenjpeg (`UnsupportedPixelFormat`)**, `UnsupportedOperation::PixelFormat` (zenpng/zenjxl/zenavif) |
+| UnsupportedOperation | `zencodec::UnsupportedOperation` (every codec) |
+| CmsRequired | zenwebp `IccSynthesisUnavailable`, zenjpeg `Icc`, + ecosystem (`zenpixels_convert::{NeedsCms,CmsError}`, `zencodecs::ColorManagement`) |
+| Cancelled / TimedOut | every codec (`StopReason`) |
+| LimitsExceeded | every codec (many variants) |
+| OutOfMemory | zenjpeg, zengif, zenavif, heic (`AllocationFailed`/`OutOfMemory`) |
+| Io | zenwebp, zenjpeg, sinks |
+| InvalidParameters | zenwebp `ValidationError` (15+), zenjpeg `InvalidQuality`/`InvalidConfig`, zenavif |
+| InvalidBuffer | zenjpeg `InvalidBufferSize`/`StrideTooSmall`, zenwebp `InvalidBufferSize`, zenbitmaps `BufferTooSmall`/`LayoutMismatch`, heic `BufferTooSmall`, + ecosystem `zenpixels::BufferError`, `garb::SizeError` |
+| InvalidState | zengif `InvalidEncoderState`, zenjpeg `TooManyRows`/`IncompleteImage`, + ecosystem `zenresize::{AlreadyFinished,RingBufferOverflow}`, metric `NoCachedReference`/`NoWarmReference` |
+| Internal | zenavif `ColorConversion`, zengif `QuantizationFailed`, heic backends, zenjxl encode, `zenquant::QuantizeError` |
+| PolicyRejected | `zenjxl::ProgressiveRejected`; pipeline-side `zenpixels_convert::{DepthReductionForbidden, AlphaRemovalForbidden, RgbToGray}` |
+
+The split the review asked for is **vindicated by zenjpeg specifically**, which
+independently distinguishes `UnsupportedFeature` *and* `UnsupportedPixelFormat`
+as separate variants — exactly the `UnsupportedImageFeature` /
+`UnsupportedPixelFormat` distinction in the taxonomy.
+
+**Policy rejection (`PolicyRejected`).** A distinct cluster means "the input is
+valid and the codec *can* handle it, but a configured policy refused":
+`zenjxl::ProgressiveRejected` ("rejected by decode policy"), and on the pipeline
+side `zenpixels_convert::{DepthReductionForbidden, AlphaRemovalForbidden,
+RgbToGray}`. This is neither malformed input nor a codec limitation — the request
+was understood and *declined* — so it gets its own category (HTTP 422-ish),
+keeping it out of the `MalformedImage`/`UnsupportedImageFeature` buckets where it
+would mislead a router.
+
+**Prior art in the workspace** (different domains, no conflict):
+`zenfleet-core::ErrorClass` (`Timeout/Oom/DecodeError/EncoderPanic/MetricNan/…`)
+classifies *fleet-job* failures; `zensim`'s `ErrorCategory`
+(`Identical/RoundingError/ChannelSwap/…`) classifies *pixel diffs*. Neither is a
+codec-error taxonomy; the name reuse is incidental.
+
+**Buffer & state (`InvalidBuffer`, `InvalidState`).** Added from the cross-codec
++ ecosystem inventory. `InvalidBuffer` is a wrong-geometry pixel buffer (size /
+stride / alignment / descriptor) — recurring as `BufferTooSmall` /
+`InvalidBufferSize` / `StrideTooSmall` / `LayoutMismatch` and `zenpixels::
+BufferError`; previously these scattered across `InvalidParameters` /
+`LimitsExceeded` / `UnsupportedPixelFormat`. `InvalidState` is API misuse /
+wrong-sequence (`InvalidEncoderState`, `TooManyRows`, `IncompleteImage`,
+`zenresize::{AlreadyFinished,RingBufferOverflow}`, metric `No*Reference`) —
+previously folded into `Internal`. Both pull a real, recurring cluster out of the
+overloaded `InvalidParameters` / `Internal` buckets.
+
+**Conclusion: right-sized at 17.** Complete coverage, every category
+load-bearing, no over-granular dead variants. `PolicyRejected` / `InvalidBuffer`
+/ `InvalidState` each pull a distinct, recurring cluster out of the
+malformed/unsupported/params/internal catch-alls.
+
+---
+
+## Discrimination gaps — codec variants that can't map *precisely*
+
+The 17 categories are complete, but a category map is only as good as the
+**source** error's granularity. Several codec variants are *insufficiently
+discriminatory*: a single variant bundles cases that belong in different
+categories, so a faithful `category()` impl has to guess. These are the variants
+worth **expanding in the codec crates** so the mapping is exact (the work lands in
+each codec repo, not here). Three failure modes:
+
+### (a) Stringly-typed catch-alls (split into discrete variants)
+A `Variant(String)` / `Variant(&str)` that spans several categories:
+
+| codec | variant | spans | should split into |
+|---|---|---|---|
+| zenpng | `Decode(String)` | malformed vs truncated-EOF vs unsupported-feature | `MalformedImage` / `UnexpectedEof` / `UnsupportedImageFeature` |
+| zenpng | `InvalidInput(String)` | malformed vs bad-params vs pixel-format | `MalformedImage` / `InvalidParameters` / `UnsupportedPixelFormat` |
+| zenavif | `Encode(String)` | bad-params vs internal vs limits | `InvalidParameters` / `Internal` / `LimitsExceeded` |
+| zenavif / heic | `Unsupported(&str)` | image-type vs feature vs pixel-format vs operation | the four `Unsupported*` categories |
+| zenjxl | `InvalidInput(String)` | malformed vs bad-params | `MalformedImage` / `InvalidParameters` |
+| zenbitmaps | `UnsupportedVariant(String)` | whole-format-type vs in-format-feature | `UnsupportedImageType` / `UnsupportedImageFeature` |
+| zengif | `GifCrate{message}` | malformed vs io vs internal (opaque wrap) | discrete variants per cause |
+
+### (b) Stringly-typed limits (lose `LimitKind`)
+`LimitExceeded(String)` maps to `LimitsExceeded(..)` but **cannot fill
+`LimitKind`** — the *which-cap* discrimination is gone. Affects **zenpng**,
+**zenwebp** (encode), **zenavif** (`ResourceLimit`), **zenjxl**, **zenbitmaps**,
+**heic**. Fix: carry the cap kind (a field/enum) or embed `zencodec::LimitExceeded`
+(which already has the kind). Contrast the codecs that *do* it well — zengif and
+zenjpeg use discrete `*TooLarge` / `ImageTooLarge` / `TooManyScans` variants that
+map straight onto `LimitKind`.
+
+### (c) Opaque wrapped sub-errors (delegate, don't collapse)
+A `#[from] <dep>::Error` mapped to one category throws away the sub-error's own
+discrimination: `zenjxl::Decode(jxl::api::Error)`,
+`zenavif::Parse(zenavif_parse::Error)`, `zenavif::ColorConversion(yuv::YuvError)`,
+`heic::HevcDecode(HevcError)`, `*::Quantize(zenquant::QuantizeError)`. Fix: have
+the inner error implement `CategorizedError` and **delegate** (`e.0.category()`),
+rather than the wrapper hard-coding `Internal`/`MalformedImage`. `HevcError` and
+`QuantizeError` are already structured enough to classify per-variant.
+
+### Scorecard
+- **Best discriminated (adopt as-is):** **zenjpeg** (distinct variants for nearly
+  every category), **zengif** (discrete limits, now `InvalidState`), **zenwebp
+  decode** (one variant per malformed case).
+- **Needs expansion before a precise map:** **zenpng** (`Decode`/`InvalidInput`/
+  `LimitExceeded` all stringly-typed), **zenjxl** (opaque `Decode`/`Encode` wraps +
+  string limit), **zenavif** (`Unsupported`/`Encode`/`ResourceLimit` strings +
+  opaque `Decode`/`Parse`), **heic** (`Unsupported(&str)` + `LimitExceeded(&str)`).
+
+None of this blocks the taxonomy — coarse codecs still map to *a* category; they
+just can't reach the *finest* one until the codec splits the variant. The 17
+categories are the target the codec error enums should be refactored toward.

--- a/docs/error-types-ecosystem.md
+++ b/docs/error-types-ecosystem.md
@@ -1,0 +1,137 @@
+# Zen ecosystem error types (non-codec) — survey
+
+Companion to [`error-taxonomy-inventory.md`](error-taxonomy-inventory.md)
+(which covers the image **codecs**). Point-in-time snapshot **2026-06-24** of the
+error types in the surrounding zen crates — pixel/colour, processing, pipeline,
+compression, metrics, and infrastructure. Useful context for whether
+`ErrorCategory` would ever need to classify *non-codec* failures a pipeline
+surfaces, and to avoid reinventing error vocabulary.
+
+Crate source layouts vary (nested workspaces): `zenpixels-convert` →
+`zenpixels/zenpixels-convert/`, `zenfilters`/`zencodecs` → `zenpipe/`,
+`zenpdf` → `zenextras/zenpdf/`, etc.
+
+## Pixel & colour
+
+- **zenpixels — `BufferError`** (`#[non_exhaustive]`, impls `Error`):
+  `AlignmentViolation`, `InsufficientData`, `StrideTooSmall`,
+  `StrideNotPixelAligned`, `InvalidDimensions`, `IncompatibleDescriptor`,
+  `AllocationFailed`.
+- **zenpixels-convert — `ConvertError`** (`#[non_exhaustive]`): `NoMatch`,
+  `NoPath`, `BufferSize`, `InvalidWidth`, `EmptyFormatList`,
+  `UnsupportedTransfer`, `AlphaNotOpaque`, `DepthReductionForbidden`,
+  `AlphaRemovalForbidden`, `RgbToGray`, `AllocationFailed`,
+  `Buffer(BufferError)`, `CmsError(String)`, `HdrSourceRequiresPeak`,
+  **`NeedsCms`** (← the ecosystem origin of `ErrorCategory::CmsRequired`).
+  Plus `CmsPluginError` (newtype over a boxed error) and
+  `cms_moxcms::MoxCmsError` (Display-only).
+- **linear-srgb** — *no public error type* (infallible conversions).
+- **garb — `SizeError`** (`#[non_exhaustive]`): `NotPixelAligned`,
+  `PixelCountMismatch`, `InvalidStride`.
+
+## Processing
+
+- **zenquant — `QuantizeError`** (`#[non_exhaustive]`): `ZeroDimension`,
+  `DimensionMismatch`, `InvalidMaxColors`, `QualityNotMet`, `DimensionOverflow`,
+  `InvalidIndex`. (zenpng wraps this → `Internal`.)
+- **zenresize — `StreamingError`** (`AlreadyFinished`, `InputTooShort`,
+  `RingBufferOverflow`) + **`CompositeError`** (`PremultipliedInput`).
+- **zenblend** — *no public error type.*
+- **zenfilters — `PipelineError`** (`UnsupportedPrimaries`, `BufferSize`,
+  `Cancelled(StopReason)`) + **`ConvenienceError`** (`Pipeline`, `Convert`,
+  `UnsupportedPrimaries`, `UnsupportedLayout`) + **`CubeParseError`**
+  (Display-only).
+- **zenlayout — `LayoutError`**: `ZeroSourceDimension`, `ZeroTargetDimension`,
+  `ZeroRegionDimension`, `NonFiniteFloat`.
+
+## Pipeline / dispatch
+
+- **zenpipe — `PipeError`**: `FormatMismatch`, `Resize`, `DimensionMismatch`,
+  `LimitExceeded`, `Cancelled`, `Op`, `Codec(Box<dyn Error>)`. Also
+  `imageflow_compat::{ZenError, TranslateError}`. Result alias is
+  `whereat::At<PipeError>`.
+- **zencodecs — `CodecError`** (`#[non_exhaustive]`): `UnrecognizedFormat`,
+  `UnsupportedFormat`, `UnsupportedOperation{format,detail}`, `DisabledFormat`,
+  `InvalidInput`, `LimitExceeded`, `Cancelled`, `Oom`, `NoSuitableEncoder`,
+  `ColorManagement(String)` (cfg `cms`), `Codec{format,source}`. Plus
+  `exif::ExifError`. **This is the closest existing analog to `ErrorCategory`** —
+  a registry-level dispatch error whose variants line up almost 1:1 with the
+  taxonomy (`UnrecognizedFormat`→UnsupportedImageType, `Oom`→OutOfMemory,
+  `ColorManagement`→CmsRequired, etc.). A future `impl CategorizedError for
+  zencodecs::CodecError` would be a natural adopter.
+- **zennode — `NodeError`**: `UnknownNode`, `UnknownParam`, `TypeMismatch`,
+  `OutOfRange`, `MissingParam`, `InvalidEnumVariant`, `Other` (graph/param
+  validation → maps to `InvalidParameters`).
+
+## Compression / container
+
+- **zenflate — `CompressionError`** (`InsufficientSpace`, `Stopped`) +
+  **`DecompressionError`** (`BadData`, `InvalidHeader`, `ChecksumMismatch`,
+  `InsufficientSpace`, `OutputLimitExceeded`, `StallLimitExceeded`, `Stopped`) +
+  `StreamError<E>`.
+- **zenzop — `Error`/`ErrorKind`** (`Interrupted`, `WriteZero`, `Cancelled`,
+  `Other` — `std::io`-style shim).
+- **zenraw — `RawError`** (`Decode`, `InvalidInput`, `Unsupported`,
+  `LimitExceeded`, `Stopped`, `Buffer(BufferError)`).
+- **zenpdf — `PdfError`**: `InvalidPdf`, `PageOutOfRange`, `DimensionOverflow`,
+  `ZeroDimensions`, `TooManyPages`, `PixelLimitExceeded`, `Buffer(#[from]
+  At<BufferError>)`, `Unsupported`, `Sink`, `LimitExceeded` — already wraps
+  `zencodec::{UnsupportedOperation, LimitExceeded}`, so it's a near-ready
+  `CategorizedError` adopter.
+- **ultrahdr — `Error`** (17 variants incl. `Stopped`, `UnsupportedFormat`,
+  `MissingInput`, `LimitExceeded`, `AllocationFailed`, `*Parse`, `Jpeg*`) +
+  `ZenDecodeError`.
+- **fax — `DecodeError<E>`** (`Reader`, `Invalid`, `Unsupported`).
+
+## Metrics (informational — not in a codec/pipeline error path)
+
+- **zensim — `ZensimError`** (`DimensionMismatch`, `ImageTooSmall`,
+  `InvalidDataLength`, `InvalidStride`, `ImageTooLarge`, `UnsupportedPixelFormat`,
+  `ModelLoadFailed`, `ModelForwardFailed`, `HdrInputRequiresPuPath`, …).
+- **zenmetrics** — every GPU metric crate (`cvvdp(-gpu)`, `ssim2-gpu`,
+  `dssim-gpu`, `butteraugli-gpu`, `zensim-gpu`, `iwssim(-gpu)`) defines its own
+  `Error` with a recurring shape: `DimensionMismatch`, `NoCachedReference`/
+  `NoWarmReference`, `InvalidImageSize`, `ModeUnsupported`, `TooBigForFull`.
+  Plus fleet types (`zenfleet-*`: `CloudError`, `LedgerError`, `DashError`,
+  `ContentError`, and **`ErrorClass`** = `Timeout/Oom/DecodeError/EncoderPanic/
+  MetricNan/UploadFail/WorkerLost/Unknown`, a job-failure classification —
+  a *parallel* idea to `ErrorCategory` but in the fleet domain).
+- **fast-ssim2 — `Ssimulacra2Error`** + `LinearRgbImageError`.
+- **butteraugli — `ButteraugliError`** (`#[non_exhaustive]`; incl.
+  `Cancelled(StopReason)`).
+
+## Infrastructure
+
+- **whereat** — *no error type*; it provides `At<E>` (the location/trace wrapper)
+  and the `ErrorAtExt`/`ResultAtExt` traits. The `At<E>` forwarding impl of
+  `CategorizedError` is what keeps a category through these wrappers.
+- **enough** — *no error type*; provides `StopReason`
+  (`Cancelled`/`TimedOut`, Display-only, **not** an `Error`) — the cancellation
+  signal codecs wrap. `ErrorCategory::{Cancelled,TimedOut}` mirror it.
+- **archmage** — `CompileTimeGuaranteedError`, `DisableAllSimdError` (SIMD-token
+  config, not an image path).
+
+## Takeaways for the taxonomy
+
+1. **CMS is a real, cross-ecosystem concern** — `NeedsCms`/`CmsError`
+   (zenpixels-convert), `ColorManagement` (zencodecs), `IccSynthesisUnavailable`
+   (zenwebp), `Icc` (zenjpeg) — which independently justifies
+   `ErrorCategory::CmsRequired` beyond a single codec.
+2. **`StopReason` is the one shared error-adjacent vocabulary** the whole
+   ecosystem already agrees on — the taxonomy aligns with it
+   (`Cancelled`/`TimedOut`).
+3. **`zencodecs::CodecError` and `zenpdf::PdfError` are ready adopters** — their
+   variants already line up with the categories; they'd be good first non-codec
+   `CategorizedError` impls.
+4. **The non-codec crates motivated three of the categories.** Conversion-policy
+   refusals (`DepthReductionForbidden` / `AlphaRemovalForbidden` / `RgbToGray`) →
+   `PolicyRejected`; buffer-geometry errors (`zenpixels::BufferError`,
+   `garb::SizeError`, the `Buffer*`/`Stride*` variants) → `InvalidBuffer`;
+   streaming/state misuse (`zenresize::{AlreadyFinished,RingBufferOverflow}`,
+   metric `No*Reference`) → `InvalidState`. With those, the **17-set** covers
+   everything the *codec* path surfaces.
+5. **The one category a *pipeline* taxonomy would still add: `DimensionMismatch`**
+   — two+ inputs that must agree in size/shape (every metric, `zenquant`,
+   `ultrahdr` HDR-vs-SDR, `zenpipe`). Codecs decode one image and never hit it, so
+   it's intentionally **out of** the codec-scoped `ErrorCategory`; a future
+   pipeline-level taxonomy (or `zencodecs::CodecError`) is where it would live.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -938,14 +938,182 @@ color/orientation/metadata before a codec runs: `docs/correctness-model.md`.
 
 ## Error utilities
 
+### `ErrorCategory` (enum) + `CategorizedError` (trait)
+
+Coarse, codec-agnostic error classification for routing (HTTP status, retry,
+logging) without naming the concrete error enum.
+
+```rust
+#[non_exhaustive]
+enum ErrorCategory {
+    MalformedImage, UnexpectedEof,
+    UnsupportedImageType, UnsupportedImageFeature, UnsupportedPixelFormat,
+    UnsupportedOperation, CmsRequired, PolicyRejected,
+    Cancelled, TimedOut, LimitsExceeded(LimitKind), OutOfMemory,
+    Io(CodecIoKind), InvalidParameters, InvalidBuffer, InvalidState, Internal,
+}
+
+trait CategorizedError: core::any::Any {
+    fn codec_name(&self) -> Option<&'static str>;  // required; cause types return None
+    fn category(&self) -> ErrorCategory;
+}
+```
+
+The "unsupported" axis is split four ways: `UnsupportedImageType` (the format
+isn't handled at all), `UnsupportedImageFeature` (a bitstream feature within a
+handled format), `UnsupportedPixelFormat` (negotiation found no common
+`PixelDescriptor`), and `UnsupportedOperation` (the requested API operation).
+`CmsRequired` flags a colour-management transform the codec won't perform itself.
+`PolicyRejected` is valid input the codec *could* handle but a configured policy
+declined (e.g. progressive content rejected by a decode policy). `InvalidBuffer`
+is a wrong-geometry pixel buffer (size/stride/alignment/descriptor) and
+`InvalidState` is API misuse (called out of sequence) — both distinct from
+`InvalidParameters` (config/knobs). `Io` carries a `CodecIoKind` — a
+`std::io::ErrorKind` when the `std` feature is enabled, empty under `no_std` (the
+variant shape is stable either way, so matching `Io(_)` is portable), anticipating
+a future `core::io::ErrorKind`.
+The set is distilled from a per-codec inventory; see
+[`error-taxonomy-inventory.md`](error-taxonomy-inventory.md) for the
+variant→category mapping and right-sizing rationale, and
+[`error-types-ecosystem.md`](error-types-ecosystem.md) for the wider ecosystem.
+
+`CategorizedError` is **opt-in** (not blanket-implemented): a codec implements it
+on its error type, mapping each variant to one category. It is **not** required
+by the `EncoderConfig`/`DecoderConfig::Error` bound, so adopting it is additive
+and back-compatible. A blanket `impl<E: CategorizedError> CategorizedError for
+whereat::At<E>` forwards to the inner error, so a located error keeps its
+category. zencodec's own cause types implement it (`LimitExceeded` →
+`LimitsExceeded(kind)`, `UnsupportedOperation` → `UnsupportedOperation` /
+`UnsupportedPixelFormat` for its `PixelFormat` arm, `enough::StopReason` →
+`Cancelled`/`TimedOut`), so a codec's mapping is usually a one-line delegation
+per arm. `LimitKind` is the value-free discriminant of `LimitExceeded`
+(`LimitExceeded::kind()`).
+
+The `codec_name()` method is where a codec declares its name —
+`fn codec_name(&self) -> Option<&'static str> { Some("zenjpeg") }` — so
+[`CodecError::from_native`] / [`of`] tag the envelope from the value instead of
+taking a codec argument. It is **required** (no default), so every implementor
+answers it; the cause types return `None` (they aren't codecs); `At<E>` forwards
+the inner `codec_name()`. It is a `&self` method rather than an associated const
+specifically so the trait stays **dyn-compatible**: with the `Any` supertrait a
+`dyn CategorizedError` can be formed *and* downcast to its concrete type — an
+associated const would forbid the trait object outright.
+
+### `CodecError` (struct)
+
+The shared error envelope: a coarse `ErrorCategory`, the originating codec's name,
+and (optionally) the codec's own detail error. A codec returns it as
+`whereat::At<CodecError>` — the recommended (and only needed) form, with the
+cleanest `?` / `.at()` ergonomics.
+
+`CodecError` is a **one-word handle** — its fields live behind a `Box` — so
+`At<CodecError>` is **two words** (handle + trace, 16 bytes on 64-bit) and every
+`Result<_, At<CodecError>>` a codec threads through `?` is two words too (the box
+pointer's niche absorbs the `Result` discriminant). That is small enough to return
+in registers rather than spill to the stack — the reason for the box: the detail is
+a *fat* `Box<dyn Error>` (16 bytes alone), so an unboxed envelope would exceed the
+16-byte ABI threshold and spill regardless of how thin the other fields are. The
+trade is one cold-path allocation per error, fine for an error type; `new` is
+therefore no longer `const`. Recovery (`codec_error()` / `error_category()`) is
+downcast-based and additionally tolerates a single consumer-applied `Box` layer in
+either position (`Box<At<CodecError>>`, `At<Box<CodecError>>`, `Box<CodecError>`);
+deeper nesting isn't covered.
+
+The codec name is an `Option<&'static str>` (`None` when unset — honest, no
+sentinel). `from_native` / `of` read it from the detail's
+[`codec_name()`](#errorcategory-enum--categorizederror-trait); `new` / `from_parts`
+(no typed detail) take it directly. `codec()` reads it back.
+
+```rust
+struct CodecError(Box<Repr>);  // Repr { category, codec: Option<&'static str>, detail: Option<Box<dyn Error + Send + Sync>> }
+
+impl CodecError {
+    fn new(codec: Option<&'static str>, category: ErrorCategory) -> Self;                     // no detail
+    fn from_native<E: CategorizedError + Error + Send + Sync + 'static>(detail: E) -> Self;    // bare; name from detail.codec_name()
+    fn of<E: CategorizedError + Error + Send + Sync + 'static>(located: At<E>) -> At<CodecError>;  // located; trace preserved
+    fn from_parts(codec: Option<&'static str>, category: ErrorCategory, detail: Box<dyn Error + Send + Sync>) -> Self;
+    fn with_codec(self, codec: Option<&'static str>) -> Self;  // builder: stamp/clear the codec name on an existing envelope
+    fn category(&self) -> ErrorCategory;             // total, fixed at construction
+    fn codec(&self) -> Option<&'static str>;         // which codec produced it (None if unset)
+    fn detail(&self) -> Option<&(dyn Error + 'static)>;
+}
+```
+
+Two ways to surface a codec error, both routable by category:
+
+- **Native enum + `CategorizedError`** (`type Error = MyError`): `category()`
+  classifies on the *typed* path. Once erased to `Box<dyn Error>` the category is
+  unreachable — the erased value is a `dyn Error`, not a `dyn CategorizedError`.
+- **The envelope** (`type Error = whereat::At<CodecError>`): because
+  `At<CodecError>` is one *concrete* type, the category **and** the codec name
+  survive erasure. A consumer recovers them from any `Box<dyn Error>` /
+  `anyhow::Error` / mapped wrapper by downcast — see `CodecErrorExt::codec_error()`
+  / `error_category()`.
+
+The **`codec` name** (`&'static str`, e.g. `"zenjpeg"`) is how a consumer tells
+codecs apart without naming any codec-specific type — useful when several codecs
+feed one pipeline. The **`detail` is optional**: `CodecError::new(codec, category)`
+is a complete error for a codec that has no error enum of its own.
+
+`from_native` / `of` read the category *and* the codec name from the detail's
+`CategorizedError` impl at construction, so both are total and never re-derived
+from an opaque chain. `of` takes an **already-located** `At<E>` (not a bare `E`):
+location is mandatory at the type level — a codec that skipped whereat can't call
+it — and the trace stays on the *outside* (`At<CodecError>`, mapping the inner
+error via whereat's trace-preserving `map_error`), never buried in the detail.
+`Display` is `"{codec}: {detail-or-category}"`; `source()` is the detail (when
+present), so the typed extractors below still reach the underlying cause.
+
+**Adoption is one impl.** A codec keeping a native `MyError: CategorizedError`
+adds `impl From<MyError> for At<CodecError>` (body: `CodecError::of(e.start_at())`,
+with `fn codec_name(&self) { Some("mycodec") }` on the error's `CategorizedError`
+impl), after which `?` on any `Result<_, MyError>` auto-wraps into the envelope —
+existing fallible internals need no rewrite. (Or convert a bare `Result<_, MyError>`
+in one step with whereat's `map_err_at(CodecError::from_native)`.) Reject stubs use `Unsupported<At<CodecError>>`. `At` and the
+`start_at()` / `.at()` ext traits are **re-exported** from the crate root
+(`zencodec::{At, ErrorAtExt, ResultAtExt}`), so a codec can name
+`zencodec::At<zencodec::CodecError>` without depending on `whereat` directly. The
+testkit's `minimal` codec is a worked example; `reference` keeps the native-enum
+form for contrast.
+
+#### Attaching structural locus (`StreamOffset`)
+
+Per-variant detail (dimensions, expected/actual, table indices) stays in the
+native error — reachable via `detail` / `find_cause`. The one piece of context
+worth carrying *generically* is **where in the input** the failure was: best-in-
+class decoders report a byte offset, and zen decoders already track it internally.
+Rather than grow a per-locus field on `CodecError`, a codec attaches it to the
+`At<CodecError>` trace as typed context, and a generic consumer recovers it by
+downcast — no codec-specific type named:
+
+```rust
+// codec, at the failure site (offset = bytes consumed):
+Err(at!(CodecError::new(Some("zenjpeg"), ErrorCategory::MalformedImage))
+    .at_data(|| StreamOffset(reader.position())))
+
+// consumer, even after erasure to Box<dyn Error>:
+let off = err.contexts().find_map(|c| c.downcast_ref::<StreamOffset>().copied());
+```
+
+`StreamOffset(pub u64)` is a shared, downcast-able newtype (bytes from the start
+of the encoded input) so the "where" convention is cross-codec. Richer loci
+(marker, box fourcc, NAL type, frame index) ride the same `at_data` / `at_str`
+channel; only the offset is standardized as a type today.
+
 ### `CodecErrorExt` (trait)
 
-Extension trait for inspecting error chains without downcasting:
+Extension trait for inspecting error chains without downcasting — the *detail*
+layer beneath `ErrorCategory` (which cap, which operation, which cause), plus
+`codec_error()` / `error_category()` which recover the `CodecError` envelope (and
+hence the category + codec name) from any erased error (`Box<dyn Error>`,
+`anyhow`):
 
 ```rust
 trait CodecErrorExt {
     fn unsupported_operation(&self) -> Option<&UnsupportedOperation>;
     fn limit_exceeded(&self) -> Option<&LimitExceeded>;
+    fn codec_error(&self) -> Option<&CodecError>;       // recover the envelope post-erasure
+    fn error_category(&self) -> Option<ErrorCategory>;  // = codec_error().map(|c| c.category())
     fn find_cause<T: core::error::Error + 'static>(&self) -> Option<&T>;
 }
 ```

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,555 @@
 //! Works with `thiserror` `#[from]` variants, `whereat::At<E>` wrappers,
 //! and any error type that properly implements `source()`.
 
-use crate::{LimitExceeded, UnsupportedOperation};
+use crate::{LimitExceeded, LimitKind, UnsupportedOperation};
+use alloc::boxed::Box;
+use enough::StopReason;
+use whereat::At;
+
+/// Coarse, codec-agnostic classification of a codec error.
+///
+/// A codec opts in by implementing [`CategorizedError`] on its error type,
+/// mapping each variant to exactly one category. Consumers then route on the
+/// category — HTTP status, retry policy, logging — without naming the concrete
+/// error enum. The set is deliberately small and `#[non_exhaustive]`; reach for
+/// the typed extractors ([`CodecErrorExt::limit_exceeded`], etc.) when you need
+/// the underlying detail.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ErrorCategory {
+    /// The encoded image is invalid or corrupt — bad bitstream content.
+    MalformedImage,
+    /// Input ended before a complete image could be read (truncated / insufficient).
+    UnexpectedEof,
+    /// The format / container / codec / profile itself is not handled at all
+    /// (e.g. "not a PNG", an unknown variant, an unsupported HEVC profile).
+    UnsupportedImageType,
+    /// The format *is* handled, but the bitstream uses a feature this codec
+    /// hasn't implemented (e.g. arithmetic-coded JPEG, an unsupported chunk).
+    UnsupportedImageFeature,
+    /// No acceptable pixel format: format negotiation found no common
+    /// [`PixelDescriptor`](zenpixels::PixelDescriptor) between what the caller
+    /// requested and what the codec can produce/accept without lossy conversion.
+    UnsupportedPixelFormat,
+    /// The requested *API operation* is not supported by this codec — the
+    /// [`UnsupportedOperation`] axis (animation, row-level, multi-image, …).
+    UnsupportedOperation,
+    /// The codec needs a colour-management transform / ICC profile it will not
+    /// perform itself (CMS is the caller's job) — e.g. an encode target whose
+    /// ICC profile cannot be synthesized. The caller must supply the transform.
+    CmsRequired,
+    /// The input is valid and the codec *could* handle it, but a configured
+    /// policy refused it — e.g. a decode policy rejecting progressive content,
+    /// or a conversion policy forbidding alpha removal / depth reduction. The
+    /// request was understood and *declined*, so it is neither malformed nor
+    /// unsupported; often maps to HTTP 422.
+    PolicyRejected,
+    /// Cooperatively cancelled via the operation's [`Stop`](enough::Stop) token.
+    Cancelled,
+    /// The operation exceeded its deadline (a [`Stop`](enough::Stop) timeout).
+    TimedOut,
+    /// A [`ResourceLimits`](crate::ResourceLimits) cap was (or would be) exceeded.
+    LimitsExceeded(LimitKind),
+    /// A memory allocation failed — distinct from a configured resource limit.
+    OutOfMemory,
+    /// An underlying I/O or output-sink operation failed. Carries a
+    /// [`CodecIoKind`] — a `std::io::ErrorKind` when the `std` feature is
+    /// enabled, empty under `no_std` (the variant shape is stable across builds).
+    Io(CodecIoKind),
+    /// Caller-supplied configuration or parameters were invalid — not the image's fault.
+    InvalidParameters,
+    /// A caller-supplied pixel buffer has an invalid layout — wrong size, stride,
+    /// alignment, or [`PixelDescriptor`](zenpixels::PixelDescriptor) for the
+    /// operation. Distinct from [`InvalidParameters`](Self::InvalidParameters)
+    /// (config/knobs): this is specifically the pixel-data buffer's geometry.
+    InvalidBuffer,
+    /// The operation was invoked in an invalid state or out of sequence — e.g.
+    /// pushing rows after `finish()`, a streaming ring-buffer overflow, or using
+    /// a cached reference before it was set. An API-protocol violation by the
+    /// caller, not bad image data.
+    InvalidState,
+    /// An internal failure: a bug, a broken invariant, or a sub-component error
+    /// not attributable to the input.
+    Internal,
+}
+
+impl core::fmt::Display for ErrorCategory {
+    /// A short human phrase — used by [`CodecError`]'s `Display` when there is no
+    /// detail error to render.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::MalformedImage => f.write_str("malformed image"),
+            Self::UnexpectedEof => f.write_str("unexpected end of input"),
+            Self::UnsupportedImageType => f.write_str("unsupported image type"),
+            Self::UnsupportedImageFeature => f.write_str("unsupported image feature"),
+            Self::UnsupportedPixelFormat => f.write_str("no acceptable pixel format"),
+            Self::UnsupportedOperation => f.write_str("unsupported operation"),
+            Self::CmsRequired => f.write_str("colour-management transform required"),
+            Self::PolicyRejected => f.write_str("rejected by policy"),
+            Self::Cancelled => f.write_str("cancelled"),
+            Self::TimedOut => f.write_str("timed out"),
+            Self::LimitsExceeded(kind) => write!(f, "resource limit exceeded ({kind:?})"),
+            Self::OutOfMemory => f.write_str("out of memory"),
+            Self::Io(_) => f.write_str("I/O error"),
+            Self::InvalidParameters => f.write_str("invalid parameters"),
+            Self::InvalidBuffer => f.write_str("invalid pixel buffer"),
+            Self::InvalidState => f.write_str("invalid state"),
+            Self::Internal => f.write_str("internal error"),
+        }
+    }
+}
+
+/// The kind of an I/O failure carried by [`ErrorCategory::Io`].
+///
+/// `core::io::ErrorKind` does not exist yet, and `std::io::ErrorKind` is
+/// unavailable under `no_std`. So this is a thin newtype that carries a
+/// `std::io::ErrorKind` **only when the `std` feature is enabled**, and is empty
+/// otherwise. The [`ErrorCategory::Io`] variant shape stays stable across builds
+/// — only this payload's internals are feature-gated — so matching `Io(_)` is
+/// portable, and `std` consumers read the [`kind`](Self::kind) when present. When
+/// `core::io::ErrorKind` stabilizes the `cfg` drops and this works under
+/// `no_std` too, with no API change.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct CodecIoKind {
+    #[cfg(feature = "std")]
+    kind: Option<std::io::ErrorKind>,
+}
+
+impl CodecIoKind {
+    /// An I/O failure with no further classification — the only form available
+    /// under `no_std`, and the `None`-kind form under `std`.
+    #[inline]
+    pub const fn opaque() -> Self {
+        Self {
+            #[cfg(feature = "std")]
+            kind: None,
+        }
+    }
+
+    /// The underlying `std::io::ErrorKind`, when the `std` feature is enabled and
+    /// one was recorded. Always `None`'s analogue (absent) under `no_std`.
+    #[cfg(feature = "std")]
+    #[inline]
+    pub const fn kind(&self) -> Option<std::io::ErrorKind> {
+        self.kind
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<std::io::ErrorKind> for CodecIoKind {
+    #[inline]
+    fn from(kind: std::io::ErrorKind) -> Self {
+        Self { kind: Some(kind) }
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<&std::io::Error> for CodecIoKind {
+    #[inline]
+    fn from(e: &std::io::Error) -> Self {
+        Self {
+            kind: Some(e.kind()),
+        }
+    }
+}
+
+/// Declares a codec error's coarse [`ErrorCategory`].
+///
+/// **Opt-in and additive.** Implement it on your error type — mapping each
+/// variant to a category — so a generic consumer can route on the category
+/// without naming the type. Unlike [`CodecErrorExt`] it is *not* blanket-
+/// implemented, so each codec declares (and can refine) its own mapping.
+///
+/// The trait requires [`Any`](core::any::Any) (so every implementor is
+/// `'static`, which an error type always is), letting a `dyn CategorizedError`
+/// be downcast to its concrete type via trait upcasting. Recovery after type
+/// erasure still goes through the concrete [`CodecError`] envelope, not a
+/// `dyn CategorizedError`.
+///
+/// A blanket impl forwards through [`whereat::At<E>`], so wrapping an error with
+/// a location trace keeps its category. zencodec's own cause types implement it
+/// too ([`LimitExceeded`], [`UnsupportedOperation`], [`enough::StopReason`]), so
+/// a codec can delegate those arms — e.g. `MyError::Cancelled(r) => r.category()`.
+///
+/// # Example
+///
+/// ```rust
+/// use zencodec::{CategorizedError, ErrorCategory, UnsupportedOperation};
+///
+/// #[derive(Debug)]
+/// enum MyError {
+///     Corrupt,
+///     Truncated,
+///     Unsupported(UnsupportedOperation),
+/// }
+///
+/// impl CategorizedError for MyError {
+///     fn codec_name(&self) -> Option<&'static str> { Some("mycodec") } // declared once
+///     fn category(&self) -> ErrorCategory {
+///         match self {
+///             MyError::Corrupt => ErrorCategory::MalformedImage,
+///             MyError::Truncated => ErrorCategory::UnexpectedEof,
+///             MyError::Unsupported(op) => op.category(), // delegate to the zencodec arm
+///         }
+///     }
+/// }
+/// assert_eq!(MyError::Corrupt.category(), ErrorCategory::MalformedImage);
+/// assert_eq!(MyError::Corrupt.codec_name(), Some("mycodec"));
+/// ```
+pub trait CategorizedError: core::any::Any {
+    /// The originating codec's name (e.g. `Some("zenjpeg")`). A codec returns a
+    /// constant here on its error type so [`CodecError::from_native`] /
+    /// [`of`](CodecError::of) can tag the envelope from the value — no separate
+    /// argument. **Required**: there is deliberately no default, so every
+    /// implementor must answer it. The zencodec cause types ([`LimitExceeded`],
+    /// [`UnsupportedOperation`], [`enough::StopReason`]) implement it as `None`
+    /// since they aren't codecs.
+    ///
+    /// It is a `&self` method (not an associated `const`) so the trait stays
+    /// [dyn-compatible](https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility)
+    /// — an associated const would forbid `dyn CategorizedError` entirely. With
+    /// the [`Any`](core::any::Any) supertrait, a `dyn CategorizedError` can be
+    /// formed *and* downcast to its concrete type.
+    fn codec_name(&self) -> Option<&'static str>;
+
+    /// This error's coarse [`ErrorCategory`].
+    fn category(&self) -> ErrorCategory;
+}
+
+/// A located error keeps both the category and the codec name of the error it
+/// wraps — [`At`] is transparent.
+impl<E: CategorizedError> CategorizedError for At<E> {
+    #[inline]
+    fn codec_name(&self) -> Option<&'static str> {
+        self.error().codec_name()
+    }
+    #[inline]
+    fn category(&self) -> ErrorCategory {
+        self.error().category()
+    }
+}
+
+impl CategorizedError for StopReason {
+    #[inline]
+    fn codec_name(&self) -> Option<&'static str> {
+        None
+    }
+    #[inline]
+    fn category(&self) -> ErrorCategory {
+        match self {
+            StopReason::TimedOut => ErrorCategory::TimedOut,
+            // `Cancelled`, plus any future `#[non_exhaustive]` reason, is a cancellation.
+            _ => ErrorCategory::Cancelled,
+        }
+    }
+}
+
+impl CategorizedError for UnsupportedOperation {
+    #[inline]
+    fn codec_name(&self) -> Option<&'static str> {
+        None
+    }
+    #[inline]
+    fn category(&self) -> ErrorCategory {
+        match self {
+            // The "no acceptable pixel format" arm is a negotiation failure, not
+            // an API-operation gap.
+            UnsupportedOperation::PixelFormat => ErrorCategory::UnsupportedPixelFormat,
+            _ => ErrorCategory::UnsupportedOperation,
+        }
+    }
+}
+
+impl CategorizedError for LimitExceeded {
+    #[inline]
+    fn codec_name(&self) -> Option<&'static str> {
+        None
+    }
+    #[inline]
+    fn category(&self) -> ErrorCategory {
+        ErrorCategory::LimitsExceeded(self.kind())
+    }
+}
+
+/// The error a zen codec returns: a coarse [`ErrorCategory`] for routing, the
+/// name of the originating codec, and (optionally) the codec's own detailed error.
+///
+/// Codecs return it as **`whereat::At<CodecError>`** — the `At` carries the
+/// location trace (extended with `.at()` as the error propagates up the codec's
+/// call tree and the caller's), while `CodecError` carries:
+/// - [`category`](Self::category) — the coarse routing axis, fixed when the error
+///   is *created* (from the native error's [`CategorizedError`] impl, or given
+///   explicitly), so it is correct and total, never re-derived from an opaque chain.
+/// - [`codec`](Self::codec) — the originating codec's name (e.g. `Some("zenjpeg")`),
+///   so a consumer can tell codecs apart without downcasting the detail.
+/// - [`detail`](Self::detail) — the codec's native error, *optional*: a codec with
+///   no error enum of its own builds a `CodecError` from a category alone
+///   (see [`new`](Self::new)).
+///
+/// The handle is one word (the fields live behind a `Box`), so `At<CodecError>`
+/// is two — small enough to return in registers, keeping every
+/// `Result<_, At<CodecError>>` a codec threads through `?` off the stack.
+///
+/// Because `At<CodecError>` is a single *concrete* type, a consumer recovers all
+/// of this after **any** erasure — a `Box<dyn Error>`, an `anyhow::Error`, or a
+/// mapped wrapper — by downcasting to it (or via [`CodecErrorExt::codec_error`] /
+/// [`error_category`](CodecErrorExt::error_category)). A trait-only classifier
+/// would be invisible through those: erasure yields a `dyn Error`, not a
+/// `dyn CategorizedError`.
+///
+/// `source()` returns the [`detail`](Self::detail) when present, so the typed
+/// extractors ([`CodecErrorExt::limit_exceeded`], `find_cause::<T>()`, …) still
+/// reach the underlying cause. `Display` is `"{codec}: {detail-or-category}"`.
+///
+/// # Example
+///
+/// ```rust
+/// use zencodec::{At, CategorizedError, CodecError, ErrorAtExt, ErrorCategory, UnsupportedOperation};
+///
+/// // A codec's native error declares its name once and maps its variants:
+/// #[derive(Debug)]
+/// struct JpegError(UnsupportedOperation);
+/// # impl core::fmt::Display for JpegError {
+/// #     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result { write!(f, "{}", self.0) }
+/// # }
+/// # impl core::error::Error for JpegError {}
+/// impl CategorizedError for JpegError {
+///     fn codec_name(&self) -> Option<&'static str> { Some("zenjpeg") }
+///     fn category(&self) -> ErrorCategory { self.0.category() }
+/// }
+///
+/// // `of` takes an already-located `At<E>`, keeps the trace on the outside, and
+/// // reads the category AND the codec name from the type — no codec arg:
+/// let e: At<CodecError> =
+///     CodecError::of(JpegError(UnsupportedOperation::AnimationEncode).start_at());
+/// assert_eq!(e.category(), ErrorCategory::UnsupportedOperation); // via At's CategorizedError
+/// assert_eq!(e.error().codec(), Some("zenjpeg"));
+///
+/// // `new` is the fundamental form — codec name passed, no detail:
+/// let bare = CodecError::new(Some("zenjpeg"), ErrorCategory::MalformedImage);
+/// assert!(bare.detail().is_none());
+///
+/// // Everything survives erasure to a trait object — recover by concrete downcast:
+/// let boxed: Box<dyn core::error::Error + Send + Sync> = Box::new(e);
+/// let recovered = boxed.downcast_ref::<At<CodecError>>().unwrap();
+/// assert_eq!(recovered.category(), ErrorCategory::UnsupportedOperation);
+/// assert_eq!(recovered.error().codec(), Some("zenjpeg"));
+/// ```
+pub struct CodecError(Box<Repr>);
+
+// Boxed so the `CodecError` handle is a single non-null word: `At<CodecError>`
+// is then two words (handle + trace) — small enough to return in registers,
+// keeping `Result<_, At<CodecError>>` off the stack on the `?` path. The detail
+// (a fat `Box<dyn Error>`) and the rest live behind the one box. Cold-path: one
+// allocation per error, which is fine for an error type.
+struct Repr {
+    category: ErrorCategory,
+    codec: Option<&'static str>,
+    detail: Option<Box<dyn core::error::Error + Send + Sync>>,
+}
+
+impl core::fmt::Debug for CodecError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CodecError")
+            .field("category", &self.0.category)
+            .field("codec", &self.0.codec)
+            .field("detail", &self.0.detail)
+            .finish()
+    }
+}
+
+impl CodecError {
+    /// A fundamental codec error: a [`category`](Self::category) and the
+    /// originating `codec` name, with **no** detail — for a codec that has no
+    /// error enum of its own. `Display` renders the category's phrase, prefixed by
+    /// the codec when present. Pass the codec name as `Some("mycodec")` (or `None`
+    /// for an unidentified error); the codec then locates it with `.start_at()` to
+    /// reach its `At<CodecError>` `type Error`.
+    #[inline]
+    pub fn new(codec: Option<&'static str>, category: ErrorCategory) -> Self {
+        CodecError(Box::new(Repr {
+            category,
+            codec,
+            detail: None,
+        }))
+    }
+
+    /// Build the envelope from a codec's native error, capturing both its
+    /// [`category()`](CategorizedError::category) and its codec name
+    /// ([`codec_name()`](CategorizedError::codec_name)) from the value — no codec
+    /// argument. Returns a bare `CodecError`; pair it with whereat's
+    /// [`map_err_at`](whereat::ResultAtExt::map_err_at) to locate and convert a
+    /// `Result<_, E>` in one step (`r.map_err_at(CodecError::from_native)?`), or
+    /// prefer [`of`](Self::of) when you already hold an `At<E>`.
+    #[inline]
+    pub fn from_native<E>(detail: E) -> Self
+    where
+        E: CategorizedError + core::error::Error + Send + Sync + 'static,
+    {
+        // The codec name comes from the value's `codec_name()`. A shared cause type
+        // (e.g. `UnsupportedOperation`, `LimitExceeded`) keeps the default `None`,
+        // so building an envelope from one directly is unidentified — wrap it in
+        // your codec's own error type first, or use `from_parts` with an explicit
+        // name. This catches that (and a codec that forgot `codec_name`) in dev; it
+        // is a no-op in release.
+        debug_assert!(
+            detail.codec_name().is_some(),
+            "CodecError built from a type with no codec_name ({}); wrap it in \
+             your codec's error type, or use from_parts with an explicit name",
+            core::any::type_name::<E>(),
+        );
+        CodecError(Box::new(Repr {
+            category: detail.category(),
+            codec: detail.codec_name(),
+            detail: Some(Box::new(detail)),
+        }))
+    }
+
+    /// Wrap a codec's **already-located** native error as `At<CodecError>`,
+    /// preserving the location trace.
+    ///
+    /// Taking `At<E>` (not a bare `E`) makes location *mandatory at the type
+    /// level*: a codec that skipped whereat cannot call `of`, so the omission is a
+    /// compile error, not a silently trace-less error. The `At` stays on the
+    /// **outside** (`At<CodecError>` — never an `At<E>` buried in the detail), so
+    /// `.at()` / [`contexts`](whereat::At::contexts) keep working on the envelope.
+    /// Typical use: `inner().map_err(CodecError::of)?`.
+    #[inline]
+    pub fn of<E>(located: At<E>) -> At<CodecError>
+    where
+        E: CategorizedError + core::error::Error + Send + Sync + 'static,
+    {
+        located.map_error(CodecError::from_native::<E>)
+    }
+
+    /// Build from an explicit category and an already-boxed detail error — for
+    /// codecs whose native error does not implement [`CategorizedError`]. `codec`
+    /// is the originating codec's name (`Some("mycodec")`), or `None` if unset.
+    #[inline]
+    pub fn from_parts(
+        codec: Option<&'static str>,
+        category: ErrorCategory,
+        detail: Box<dyn core::error::Error + Send + Sync>,
+    ) -> Self {
+        CodecError(Box::new(Repr {
+            category,
+            codec,
+            detail: Some(detail),
+        }))
+    }
+
+    /// Set (or clear) the originating codec name on an existing envelope.
+    ///
+    /// Since the codec name is optional and defaults to `None`, this is the way to
+    /// stamp it after the fact — for a `CodecError` built without one (e.g.
+    /// [`from_parts`](Self::from_parts) with `None`, or a generic helper that
+    /// wrapped a foreign error) that a codec then wants to attribute to itself.
+    /// Builder form, so it chains:
+    /// `CodecError::from_parts(None, cat, e).with_codec(Some("zenjpeg"))`. For the
+    /// located form, apply it before locating, or via
+    /// `at.map_error(|e| e.with_codec(Some("zenjpeg")))`.
+    #[inline]
+    #[must_use]
+    pub fn with_codec(mut self, codec: Option<&'static str>) -> Self {
+        self.0.codec = codec;
+        self
+    }
+
+    /// The coarse category — fixed at construction, total, allocation-free.
+    #[inline]
+    pub fn category(&self) -> ErrorCategory {
+        self.0.category
+    }
+
+    /// The originating codec's name (e.g. `Some("zenjpeg")`), or `None` if unset.
+    #[inline]
+    pub fn codec(&self) -> Option<&'static str> {
+        self.0.codec
+    }
+
+    /// The codec's native error (its message and its own `source()` chain), if any.
+    #[inline]
+    pub fn detail(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        self.0
+            .detail
+            .as_deref()
+            .map(|d| d as &(dyn core::error::Error + 'static))
+    }
+}
+
+/// The envelope is itself categorized: `category()` and `codec_name()` return its
+/// stored fields, so a bare `CodecError` — and `At<CodecError>` via the blanket
+/// [`At`] impl — both answer [`CategorizedError`]. (Here the codec name really is
+/// per-instance, read from [`codec`](CodecError::codec), since one envelope type
+/// fronts every codec.)
+impl CategorizedError for CodecError {
+    #[inline]
+    fn codec_name(&self) -> Option<&'static str> {
+        self.0.codec
+    }
+    #[inline]
+    fn category(&self) -> ErrorCategory {
+        self.0.category
+    }
+}
+
+impl core::fmt::Display for CodecError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // "{codec}: {detail-or-category}". The category is a separate axis; it is
+        // rendered as text only when there is no detail message to show.
+        if let Some(codec) = self.0.codec {
+            write!(f, "{codec}: ")?;
+        }
+        match &self.0.detail {
+            Some(detail) => core::fmt::Display::fmt(detail, f),
+            None => core::fmt::Display::fmt(&self.0.category, f),
+        }
+    }
+}
+
+impl core::error::Error for CodecError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        self.0
+            .detail
+            .as_deref()
+            .map(|d| d as &(dyn core::error::Error + 'static))
+    }
+}
+
+/// A byte offset into the **encoded input**, for attaching to an error's
+/// location trace as retrievable context.
+///
+/// The most useful diagnostic a decoder can give is *where* in the input it
+/// failed — and decoders already track this internally. Rather than grow a
+/// per-locus field on [`CodecError`], a codec attaches the offset to its
+/// `At<CodecError>` trace as typed context with
+/// [`At::at_data`](whereat::At::at_data). It is a shared type so a generic
+/// consumer can recover it by [`downcast_ref`](whereat::AtContextRef::downcast_ref)
+/// **without naming any codec-specific type** — the cross-codec convention for
+/// "where did it fail". The unit is bytes from the start of the encoded input.
+///
+/// ```rust
+/// use zencodec::{At, CodecError, ErrorAtExt, ErrorCategory, StreamOffset};
+///
+/// // A codec attaches the offset where parsing failed to its error's trace:
+/// let err: At<CodecError> = CodecError::new(Some("zenjpeg"), ErrorCategory::MalformedImage)
+///     .start_at()
+///     .at_data(|| StreamOffset(42));
+///
+/// // A generic consumer recovers it — even after erasure to `Box<dyn Error>`:
+/// let boxed: Box<dyn core::error::Error + Send + Sync> = Box::new(err);
+/// let at = boxed.downcast_ref::<At<CodecError>>().unwrap();
+/// let offset = at.contexts().find_map(|c| c.downcast_ref::<StreamOffset>().copied());
+/// assert_eq!(offset, Some(StreamOffset(42)));
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct StreamOffset(pub u64);
+
+impl core::fmt::Display for StreamOffset {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "byte offset {}", self.0)
+    }
+}
 
 /// Extension trait for inspecting codec errors.
 ///
@@ -18,6 +566,8 @@ use crate::{LimitExceeded, UnsupportedOperation};
 ///
 /// Works through any wrapper that delegates `source()`:
 /// `thiserror` `#[from]` variants, `whereat::At<E>`, `Box<dyn Error>`, etc.
+/// For coarse routing prefer a codec's [`CategorizedError`] impl; these typed
+/// extractors recover the underlying cause when you need its detail.
 ///
 /// # Example
 ///
@@ -40,8 +590,62 @@ pub trait CodecErrorExt {
     /// Find a [`LimitExceeded`] in this error's cause chain.
     fn limit_exceeded(&self) -> Option<&LimitExceeded>;
 
+    /// Recover the shared [`CodecError`] envelope from this error's chain — after
+    /// **any** erasure (`Box<dyn Error>`, `anyhow::Error`, a mapped wrapper) — by
+    /// downcasting to the concrete `At<CodecError>` (or a bare `CodecError`),
+    /// tolerating a single `Box` layer (`Box<At<CodecError>>` etc., so a codec may
+    /// use an 8-byte boxed `type Error`). It gives the
+    /// [`category`](CodecError::category) *and* the originating
+    /// [`codec`](CodecError::codec) name, so a consumer can tell codecs apart
+    /// without naming any codec-specific type.
+    ///
+    /// `None` only when the error did not originate from a zen codec via the
+    /// envelope. The provided default returns `None`; the blanket impl over
+    /// `core::error::Error` and the `dyn Error` impls override it with the real
+    /// lookup.
+    fn codec_error(&self) -> Option<&CodecError> {
+        None
+    }
+
+    /// Shortcut for
+    /// [`codec_error()`](Self::codec_error)`.map(CodecError::category)` — the
+    /// coarse axis app/lib code routes on.
+    fn error_category(&self) -> Option<ErrorCategory> {
+        self.codec_error().map(CodecError::category)
+    }
+
     /// Find a cause of arbitrary type `T` in this error's cause chain.
     fn find_cause<T: core::error::Error + 'static>(&self) -> Option<&T>;
+}
+
+/// Recover the shared [`CodecError`] envelope from an error chain, tolerating a
+/// single `Box` layer in either position. Backs [`CodecErrorExt::codec_error`].
+///
+/// Recovery is downcast-based, so it must name the concrete shapes it accepts: the
+/// canonical `At<CodecError>` (and bare `CodecError`), plus a one-deep `Box` a
+/// caller may have applied — `Box<At<CodecError>>`, `At<Box<CodecError>>`, and
+/// `Box<CodecError>`. (`CodecError` is already a one-word handle, so a codec's
+/// `type Error = At<CodecError>` needs no extra boxing; these probes cover a
+/// consumer that boxed anyway.) A `Box`'s `source()` forwards *past* the envelope,
+/// so each boxed shape needs its own probe rather than falling out of the chain
+/// walk; deeper nesting (`Box<Box<…>>`) is not covered (and shouldn't occur).
+fn recover_codec_error<'a>(err: &'a (dyn core::error::Error + 'static)) -> Option<&'a CodecError> {
+    if let Some(at) = find_cause::<At<CodecError>>(err) {
+        return Some(at.error());
+    }
+    if let Some(ce) = find_cause::<CodecError>(err) {
+        return Some(ce);
+    }
+    if let Some(b) = find_cause::<Box<At<CodecError>>>(err) {
+        return Some(b.error());
+    }
+    if let Some(at) = find_cause::<At<Box<CodecError>>>(err) {
+        return Some(&**at.error());
+    }
+    if let Some(b) = find_cause::<Box<CodecError>>(err) {
+        return Some(&**b);
+    }
+    None
 }
 
 impl<E: core::error::Error + 'static> CodecErrorExt for E {
@@ -51,6 +655,10 @@ impl<E: core::error::Error + 'static> CodecErrorExt for E {
 
     fn limit_exceeded(&self) -> Option<&LimitExceeded> {
         find_cause::<LimitExceeded>(self)
+    }
+
+    fn codec_error(&self) -> Option<&CodecError> {
+        recover_codec_error(self)
     }
 
     fn find_cause<T: core::error::Error + 'static>(&self) -> Option<&T> {
@@ -68,6 +676,10 @@ impl CodecErrorExt for dyn core::error::Error + Send + Sync + 'static {
         find_cause::<LimitExceeded>(self)
     }
 
+    fn codec_error(&self) -> Option<&CodecError> {
+        recover_codec_error(self)
+    }
+
     fn find_cause<T: core::error::Error + 'static>(&self) -> Option<&T> {
         find_cause::<T>(self)
     }
@@ -82,6 +694,10 @@ impl CodecErrorExt for dyn core::error::Error + Send + 'static {
         find_cause::<LimitExceeded>(self)
     }
 
+    fn codec_error(&self) -> Option<&CodecError> {
+        recover_codec_error(self)
+    }
+
     fn find_cause<T: core::error::Error + 'static>(&self) -> Option<&T> {
         find_cause::<T>(self)
     }
@@ -94,6 +710,10 @@ impl CodecErrorExt for dyn core::error::Error + 'static {
 
     fn limit_exceeded(&self) -> Option<&LimitExceeded> {
         find_cause::<LimitExceeded>(self)
+    }
+
+    fn codec_error(&self) -> Option<&CodecError> {
+        recover_codec_error(self)
     }
 
     fn find_cause<T: core::error::Error + 'static>(&self) -> Option<&T> {
@@ -127,12 +747,20 @@ mod tests {
     use alloc::string::String;
     use core::fmt;
 
-    // A simple codec error with source() chain via manual impl
+    // A codec error that opts into CategorizedError and exposes typed causes
+    // via source() — exactly the pattern a real codec follows.
     #[derive(Debug)]
     enum TestCodecError {
         Limit(LimitExceeded),
         Unsupported(UnsupportedOperation),
-        Other(String),
+        Cancelled(StopReason),
+        Malformed(String),
+        // Valid input the codec could handle, refused by a configured policy.
+        RejectedByPolicy,
+        // Caller-supplied pixel buffer has the wrong geometry.
+        BadBuffer,
+        // API called out of sequence (e.g. push after finish).
+        WrongState,
     }
 
     impl fmt::Display for TestCodecError {
@@ -140,7 +768,11 @@ mod tests {
             match self {
                 Self::Limit(e) => write!(f, "limit: {e}"),
                 Self::Unsupported(e) => write!(f, "unsupported: {e}"),
-                Self::Other(s) => write!(f, "other: {s}"),
+                Self::Cancelled(r) => write!(f, "cancelled: {r}"),
+                Self::Malformed(s) => write!(f, "malformed: {s}"),
+                Self::RejectedByPolicy => write!(f, "rejected by policy"),
+                Self::BadBuffer => write!(f, "bad buffer"),
+                Self::WrongState => write!(f, "wrong state"),
             }
         }
     }
@@ -150,7 +782,29 @@ mod tests {
             match self {
                 Self::Limit(e) => Some(e),
                 Self::Unsupported(e) => Some(e),
-                Self::Other(_) => None,
+                // StopReason is not an Error, so it isn't a source link.
+                Self::Cancelled(_)
+                | Self::Malformed(_)
+                | Self::RejectedByPolicy
+                | Self::BadBuffer
+                | Self::WrongState => None,
+            }
+        }
+    }
+
+    impl CategorizedError for TestCodecError {
+        fn codec_name(&self) -> Option<&'static str> {
+            Some("test-codec")
+        }
+        fn category(&self) -> ErrorCategory {
+            match self {
+                Self::Limit(e) => e.category(),
+                Self::Unsupported(e) => e.category(),
+                Self::Cancelled(r) => r.category(),
+                Self::Malformed(_) => ErrorCategory::MalformedImage,
+                Self::RejectedByPolicy => ErrorCategory::PolicyRejected,
+                Self::BadBuffer => ErrorCategory::InvalidBuffer,
+                Self::WrongState => ErrorCategory::InvalidState,
             }
         }
     }
@@ -185,7 +839,7 @@ mod tests {
 
     #[test]
     fn ext_returns_none_when_absent() {
-        let err = TestCodecError::Other("something else".into());
+        let err = TestCodecError::Malformed("something else".into());
         assert!(err.limit_exceeded().is_none());
         assert!(err.unsupported_operation().is_none());
     }
@@ -217,5 +871,332 @@ mod tests {
         };
         let found = find_cause::<LimitExceeded>(&err);
         assert_eq!(found, Some(&err));
+    }
+
+    // ---- CategorizedError ----
+
+    #[test]
+    fn category_maps_each_codec_variant() {
+        assert_eq!(
+            TestCodecError::Malformed("x".into()).category(),
+            ErrorCategory::MalformedImage
+        );
+        assert_eq!(
+            TestCodecError::RejectedByPolicy.category(),
+            ErrorCategory::PolicyRejected
+        );
+        assert_eq!(
+            TestCodecError::BadBuffer.category(),
+            ErrorCategory::InvalidBuffer
+        );
+        assert_eq!(
+            TestCodecError::WrongState.category(),
+            ErrorCategory::InvalidState
+        );
+        assert_eq!(
+            TestCodecError::Unsupported(UnsupportedOperation::AnimationEncode).category(),
+            ErrorCategory::UnsupportedOperation
+        );
+        assert_eq!(
+            TestCodecError::Cancelled(StopReason::Cancelled).category(),
+            ErrorCategory::Cancelled
+        );
+        assert_eq!(
+            TestCodecError::Cancelled(StopReason::TimedOut).category(),
+            ErrorCategory::TimedOut
+        );
+        assert_eq!(
+            TestCodecError::Limit(LimitExceeded::Pixels { actual: 9, max: 4 }).category(),
+            ErrorCategory::LimitsExceeded(LimitKind::Pixels)
+        );
+    }
+
+    #[test]
+    fn zencodec_cause_types_categorize() {
+        assert_eq!(StopReason::Cancelled.category(), ErrorCategory::Cancelled);
+        assert_eq!(StopReason::TimedOut.category(), ErrorCategory::TimedOut);
+        // The operation axis splits: a plain operation vs the pixel-format arm.
+        assert_eq!(
+            UnsupportedOperation::AnimationDecode.category(),
+            ErrorCategory::UnsupportedOperation
+        );
+        assert_eq!(
+            UnsupportedOperation::PixelFormat.category(),
+            ErrorCategory::UnsupportedPixelFormat
+        );
+        assert_eq!(
+            LimitExceeded::Memory { actual: 2, max: 1 }.category(),
+            ErrorCategory::LimitsExceeded(LimitKind::Memory)
+        );
+    }
+
+    #[test]
+    fn category_is_preserved_through_at() {
+        // A located error (the form heic/zenbitmaps return) keeps its category,
+        // and the inner error is still reachable for its detail.
+        let located = At::wrap(TestCodecError::Cancelled(StopReason::TimedOut));
+        assert_eq!(located.category(), ErrorCategory::TimedOut);
+        assert!(matches!(
+            located.error(),
+            TestCodecError::Cancelled(StopReason::TimedOut)
+        ));
+    }
+
+    // ---- CodecError envelope ----
+
+    #[test]
+    fn codec_error_from_native_and_of_capture_category_and_codec() {
+        // `from_native` reads both the category and the codec name from the type.
+        let e = CodecError::from_native(TestCodecError::Malformed("bad".into()));
+        assert_eq!(e.category(), ErrorCategory::MalformedImage);
+        assert_eq!(e.codec(), Some("test-codec")); // TestCodecError::codec_name
+        assert!(e.detail().is_some());
+        // Display is "{codec}: {detail message}".
+        assert_eq!(alloc::format!("{e}"), "test-codec: malformed: bad");
+        // `of` is the located form: takes At<E>, keeps the trace on the outside.
+        let located: At<CodecError> =
+            CodecError::of(At::wrap(TestCodecError::Malformed("bad".into())));
+        assert_eq!(located.category(), ErrorCategory::MalformedImage);
+        assert_eq!(located.error().codec(), Some("test-codec"));
+        // from_parts takes an explicit category + codec name (no typed detail):
+        let e2 = CodecError::from_parts(
+            Some("zenjpeg"),
+            ErrorCategory::Io(CodecIoKind::opaque()),
+            Box::new(TestCodecError::Malformed("x".into())),
+        );
+        assert_eq!(e2.category(), ErrorCategory::Io(CodecIoKind::opaque()));
+        assert_eq!(e2.codec(), Some("zenjpeg"));
+    }
+
+    #[test]
+    fn codec_error_new_is_detail_free() {
+        // The fundamental form: a codec with no error enum of its own.
+        let e = CodecError::new(Some("zenpng"), ErrorCategory::MalformedImage);
+        assert_eq!(e.category(), ErrorCategory::MalformedImage);
+        assert_eq!(e.codec(), Some("zenpng"));
+        assert!(e.detail().is_none());
+        // With no detail, Display falls back to the category's phrase.
+        assert_eq!(alloc::format!("{e}"), "zenpng: malformed image");
+    }
+
+    #[test]
+    fn codec_error_recovers_through_box_dyn_error() {
+        // The dyn-dispatch path: At<CodecError> erased to Box<dyn Error>. Both the
+        // category AND the originating codec name survive erasure.
+        let located = CodecError::of(At::wrap(TestCodecError::Cancelled(StopReason::Cancelled)));
+        let boxed: Box<dyn core::error::Error + Send + Sync> = Box::new(located);
+        assert_eq!(boxed.error_category(), Some(ErrorCategory::Cancelled));
+        assert_eq!(
+            boxed.codec_error().and_then(CodecError::codec),
+            Some("test-codec")
+        );
+        // A bare CodecError (no At) recovers too.
+        let bare: Box<dyn core::error::Error + Send + Sync> =
+            Box::new(CodecError::from_native(TestCodecError::WrongState));
+        assert_eq!(bare.error_category(), Some(ErrorCategory::InvalidState));
+        assert_eq!(
+            bare.codec_error().and_then(CodecError::codec),
+            Some("test-codec")
+        );
+        // A non-codec error has no envelope.
+        let other: Box<dyn core::error::Error + Send + Sync> =
+            Box::new(TestCodecError::Malformed("not wrapped".into()));
+        assert_eq!(other.error_category(), None);
+        assert!(other.codec_error().is_none());
+    }
+
+    #[test]
+    fn codec_error_recovers_through_a_wrapping_error() {
+        // The "map to own type / anyhow" path: a consumer error whose source()
+        // is the At<CodecError>. codec_error() walks the chain and downcasts to it.
+        #[derive(Debug)]
+        struct Wrap(At<CodecError>);
+        impl fmt::Display for Wrap {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "wrap: {}", self.0)
+            }
+        }
+        impl core::error::Error for Wrap {
+            fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+                Some(&self.0)
+            }
+        }
+        let wrapped = Wrap(CodecError::of(At::wrap(TestCodecError::Limit(
+            LimitExceeded::Pixels { actual: 9, max: 4 },
+        ))));
+        assert_eq!(
+            wrapped.error_category(),
+            Some(ErrorCategory::LimitsExceeded(LimitKind::Pixels))
+        );
+        assert_eq!(
+            wrapped.codec_error().and_then(CodecError::codec),
+            Some("test-codec")
+        );
+    }
+
+    #[test]
+    fn codec_error_typed_cause_still_findable() {
+        // The native cause stays reachable via source()/find_cause for detail,
+        // alongside the coarse category.
+        let inner = LimitExceeded::Memory { actual: 9, max: 4 };
+        let located = CodecError::of(At::wrap(TestCodecError::Limit(inner.clone())));
+        assert_eq!(located.limit_exceeded(), Some(&inner));
+        assert_eq!(
+            located.error_category(),
+            Some(ErrorCategory::LimitsExceeded(LimitKind::Memory))
+        );
+    }
+
+    #[test]
+    fn codec_error_at_trace_is_present() {
+        // `.at()` builds the trace on the outer At<CodecError>; Debug renders it.
+        let e = CodecError::of(At::wrap(TestCodecError::Malformed("x".into()))).at();
+        let dbg = alloc::format!("{e:?}");
+        assert!(
+            dbg.contains("at "),
+            "trace frame should render in Debug: {dbg}"
+        );
+    }
+
+    #[test]
+    fn stream_offset_rides_the_trace_through_erasure() {
+        // The shared locus convention: a byte offset attached as trace context,
+        // recovered generically (no codec-specific type named) after erasure.
+        let err = At::wrap(CodecError::new(
+            Some("zenjpeg"),
+            ErrorCategory::MalformedImage,
+        ))
+        .at_data(|| StreamOffset(1234));
+        let boxed: Box<dyn core::error::Error + Send + Sync> = Box::new(err);
+        let at = boxed
+            .downcast_ref::<At<CodecError>>()
+            .expect("downcast to the concrete envelope");
+        let offset = at
+            .contexts()
+            .find_map(|c| c.downcast_ref::<StreamOffset>().copied());
+        assert_eq!(offset, Some(StreamOffset(1234)));
+        // The category recovers alongside the locus.
+        assert_eq!(boxed.error_category(), Some(ErrorCategory::MalformedImage));
+    }
+
+    #[test]
+    fn error_types_stay_small() {
+        use core::mem::size_of;
+        let word = size_of::<usize>();
+        // `CodecError` is a boxed handle — one non-null word — so `At<CodecError>`
+        // is two (handle + trace), and every `Result<_, At<CodecError>>` a codec
+        // threads through `?` is two words too (the box pointer's niche absorbs the
+        // discriminant): small enough to return in registers rather than spill to
+        // the stack. Guards against the handle un-boxing or the trace growing.
+        // (Word-relative so it holds on 32-bit too, e.g. i686.)
+        assert!(
+            size_of::<CodecError>() <= word,
+            "CodecError = {} bytes (expected <= {})",
+            size_of::<CodecError>(),
+            word
+        );
+        assert!(
+            size_of::<At<CodecError>>() <= 2 * word,
+            "At<CodecError> = {} bytes (expected <= {})",
+            size_of::<At<CodecError>>(),
+            2 * word
+        );
+        assert!(
+            size_of::<Result<(), At<CodecError>>>() <= 2 * word,
+            "Result<(), At<CodecError>> = {} bytes (expected <= {})",
+            size_of::<Result<(), At<CodecError>>>(),
+            2 * word
+        );
+    }
+    #[test]
+    fn recovery_tolerates_a_single_box_layer() {
+        // Recovery is downcast-based, but probes a single `Box` layer in either
+        // position too, so a consumer that boxed the (already one-word) envelope is
+        // still classifiable.
+        let mk = || CodecError::new(Some("zenjpeg"), ErrorCategory::MalformedImage);
+
+        // Canonical `At<CodecError>`.
+        let canonical: Box<dyn core::error::Error + Send + Sync> = Box::new(At::wrap(mk()));
+        assert_eq!(
+            canonical.error_category(),
+            Some(ErrorCategory::MalformedImage)
+        );
+        assert_eq!(
+            canonical.codec_error().and_then(CodecError::codec),
+            Some("zenjpeg")
+        );
+
+        // `Box<At<CodecError>>` — a consumer-applied box.
+        let boxed_at: Box<dyn core::error::Error + Send + Sync> =
+            Box::new(Box::new(At::wrap(mk())) as Box<At<CodecError>>);
+        assert_eq!(
+            boxed_at.error_category(),
+            Some(ErrorCategory::MalformedImage)
+        );
+        assert_eq!(
+            boxed_at.codec_error().and_then(CodecError::codec),
+            Some("zenjpeg")
+        );
+
+        // `At<Box<CodecError>>`.
+        let at_boxed: Box<dyn core::error::Error + Send + Sync> =
+            Box::new(At::wrap(Box::new(mk()) as Box<CodecError>));
+        assert_eq!(
+            at_boxed.error_category(),
+            Some(ErrorCategory::MalformedImage)
+        );
+
+        // `Box<CodecError>` (no `At`).
+        let bare_boxed: Box<dyn core::error::Error + Send + Sync> =
+            Box::new(Box::new(mk()) as Box<CodecError>);
+        assert_eq!(
+            bare_boxed.error_category(),
+            Some(ErrorCategory::MalformedImage)
+        );
+
+        // The fallback is one layer deep — a pathological double box is not covered.
+        let double: Box<dyn core::error::Error + Send + Sync> =
+            Box::new(Box::new(Box::new(At::wrap(mk())) as Box<At<CodecError>>));
+        assert_eq!(double.error_category(), None);
+    }
+
+    #[test]
+    fn io_kind_variant_is_portable_and_carries_kind_under_std() {
+        // The variant shape is stable across builds; matching `Io(_)` is portable.
+        let cat = ErrorCategory::Io(CodecIoKind::opaque());
+        assert!(matches!(cat, ErrorCategory::Io(_)));
+        #[cfg(feature = "std")]
+        {
+            let k: CodecIoKind = std::io::ErrorKind::UnexpectedEof.into();
+            assert_eq!(k.kind(), Some(std::io::ErrorKind::UnexpectedEof));
+            assert_eq!(CodecIoKind::opaque().kind(), None);
+        }
+    }
+
+    #[test]
+    fn categorized_error_is_dyn_downcastable_via_any() {
+        // `CategorizedError: Any` lets a `dyn CategorizedError` upcast to `dyn Any`
+        // and downcast to the concrete type (recovery still prefers the envelope).
+        use core::any::Any;
+        let err = TestCodecError::WrongState;
+        let dynamic: &dyn CategorizedError = &err;
+        assert_eq!(dynamic.category(), ErrorCategory::InvalidState);
+        let any: &dyn Any = dynamic; // trait upcasting (Rust 1.86+)
+        assert!(any.downcast_ref::<TestCodecError>().is_some());
+    }
+
+    #[test]
+    fn with_codec_stamps_or_clears_the_name() {
+        // A foreign error wrapped with no codec name, then stamped via the builder.
+        let e = CodecError::from_parts(
+            None,
+            ErrorCategory::Internal,
+            Box::new(TestCodecError::Malformed("x".into())),
+        );
+        assert_eq!(e.codec(), None);
+        let stamped = e.with_codec(Some("zenjpeg"));
+        assert_eq!(stamped.codec(), Some("zenjpeg"));
+        // It can also clear the name back to None.
+        assert_eq!(stamped.with_codec(None).codec(), None);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,12 @@
 
 extern crate alloc;
 
+// Pulled in only by the `std` feature, solely so [`CodecIoKind`] can carry a
+// `std::io::ErrorKind` on the I/O category. The crate stays `#![no_std]`; when
+// `core::io::ErrorKind` stabilizes this can drop.
+#[cfg(feature = "std")]
+extern crate std;
+
 whereat::define_at_crate_info!();
 
 mod capabilities;
@@ -93,7 +99,7 @@ pub use info::{
     Cicp, ContentLightLevel, ImageInfo, ImageSequence, MasteringDisplay, Resolution,
     ResolutionUnit, SourceColor, Supplements,
 };
-pub use limits::{AllocPreference, LimitExceeded, ResourceLimits, ThreadingPolicy};
+pub use limits::{AllocPreference, LimitExceeded, LimitKind, ResourceLimits, ThreadingPolicy};
 pub use metadata::{IccRetention, Metadata, MetadataFields, MetadataPolicy};
 pub use orientation::{Orientation, OrientationHint};
 pub use output::{AnimationFrame, OwnedAnimationFrame};
@@ -101,7 +107,10 @@ pub use zenpixels::ColorAuthority;
 
 pub use capabilities::UnsupportedOperation;
 pub use detect::SourceEncodingDetails;
-pub use error::{CodecErrorExt, find_cause};
+pub use error::{
+    CategorizedError, CodecError, CodecErrorExt, CodecIoKind, ErrorCategory, StreamOffset,
+    find_cause,
+};
 pub use traits::Unsupported;
 
 // =========================================================================
@@ -116,6 +125,18 @@ pub use traits::Unsupported;
 pub use almost_enough::StopToken;
 pub use enough;
 pub use enough::Unstoppable;
+
+/// Location-tracing error wrapper, re-exported from [`whereat`].
+///
+/// `whereat::At` is already part of this crate's public surface (the blanket
+/// `impl CategorizedError for At<E>`), so re-exporting it adds no new coupling.
+/// It is re-exported because [`At<CodecError>`](crate::CodecError) is the
+/// recommended codec `Error` type: a codec can name
+/// `zencodec::At<zencodec::CodecError>` and reach `start_at()` / `.at()` (via the
+/// re-exported [`ErrorAtExt`] / [`ResultAtExt`]) without depending on `whereat`
+/// directly.
+pub use whereat;
+pub use whereat::{At, ErrorAtExt, ResultAtExt};
 
 // =========================================================================
 // pub(crate) re-exports — keep internal `use crate::Foo` paths working

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -708,6 +708,51 @@ pub enum LimitExceeded {
     },
 }
 
+/// Which resource cap a [`LimitExceeded`] refers to, without the actual/max
+/// values. Carried by
+/// [`ErrorCategory::LimitsExceeded`](crate::ErrorCategory::LimitsExceeded)
+/// for routing; obtain it from [`LimitExceeded::kind`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum LimitKind {
+    /// [`LimitExceeded::Width`].
+    Width,
+    /// [`LimitExceeded::Height`].
+    Height,
+    /// [`LimitExceeded::Pixels`].
+    Pixels,
+    /// [`LimitExceeded::Memory`].
+    Memory,
+    /// [`LimitExceeded::InputSize`].
+    InputSize,
+    /// [`LimitExceeded::OutputSize`].
+    OutputSize,
+    /// [`LimitExceeded::Frames`].
+    Frames,
+    /// [`LimitExceeded::Duration`].
+    Duration,
+    /// [`LimitExceeded::TotalPixels`].
+    TotalPixels,
+}
+
+impl LimitExceeded {
+    /// Which cap was exceeded, without the actual/max values — for coarse
+    /// routing via [`ErrorCategory`](crate::ErrorCategory).
+    pub fn kind(&self) -> LimitKind {
+        match self {
+            Self::Width { .. } => LimitKind::Width,
+            Self::Height { .. } => LimitKind::Height,
+            Self::Pixels { .. } => LimitKind::Pixels,
+            Self::Memory { .. } => LimitKind::Memory,
+            Self::InputSize { .. } => LimitKind::InputSize,
+            Self::OutputSize { .. } => LimitKind::OutputSize,
+            Self::Frames { .. } => LimitKind::Frames,
+            Self::Duration { .. } => LimitKind::Duration,
+            Self::TotalPixels { .. } => LimitKind::TotalPixels,
+        }
+    }
+}
+
 impl core::fmt::Display for LimitExceeded {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {

--- a/zencodec-testkit/Cargo.toml
+++ b/zencodec-testkit/Cargo.toml
@@ -16,6 +16,9 @@ include = ["/src/**", "/README.md", "/LICENSE*"]
 zencodec = { path = "..", version = "0.1.21" }
 zenpixels = { version = "0.2.10", features = ["icc"] }
 enough = "0.4.4"
+# The `minimal` codec uses `type Error = At<CodecError>` (the envelope pattern),
+# the way real codecs do — they depend on whereat directly to name `At<…>`.
+whereat = "0.1.5"
 
 [dev-dependencies]
 # For the decode-parallelism examples (tests/decode_parallelism.rs) — exercises

--- a/zencodec-testkit/src/lib.rs
+++ b/zencodec-testkit/src/lib.rs
@@ -1224,6 +1224,105 @@ mod tests {
         check_capability_honesty(e, d, &TestImage::rgba8_gradient(12, 9)).unwrap();
     }
 
+    /// A real reference-codec operation cancelled via its `Stop` token surfaces
+    /// an error whose [`ErrorCategory`] is `Cancelled` — classified through the
+    /// codec's opt-in [`CategorizedError`] impl, no concrete-enum match needed
+    /// (issue #99). This is what lets a server map a cancelled request to HTTP
+    /// 499 instead of treating it as malformed input.
+    #[test]
+    fn reference_cancellation_is_classifiable() {
+        use enough::{Stop, StopReason};
+        use zencodec::{CategorizedError, CodecErrorExt, ErrorCategory};
+
+        // A token already in the stopped state — the codec's first check fires.
+        struct Cancelled;
+        impl Stop for Cancelled {
+            fn check(&self) -> Result<(), StopReason> {
+                Err(StopReason::Cancelled)
+            }
+        }
+
+        let img = TestImage::rgba8_gradient(8, 8);
+        let mut a = ReferenceEncoderConfig::new()
+            .job()
+            .animation_frame_encoder()
+            .expect("animation encoder");
+        let err = a
+            .push_frame(img.as_slice(), 40, Some(&Cancelled))
+            .expect_err("a fired stop token must cancel the push");
+
+        // Classify it the way a generic consumer would, with no knowledge of RefError:
+        assert_eq!(err.category(), ErrorCategory::Cancelled);
+        // ...and it must NOT be mistaken for a limit or an unsupported operation.
+        assert!(err.limit_exceeded().is_none());
+        assert!(err.unsupported_operation().is_none());
+    }
+
+    /// The envelope pattern (`type Error = At<CodecError>`, the `minimal` codec)
+    /// lets a generic consumer recover the [`ErrorCategory`] *after dyn dispatch
+    /// erases the concrete error to `BoxedError`* — the case typed-only
+    /// classification (issue #99) can't reach, because the erased value is a
+    /// `dyn Error`, not a `dyn CategorizedError`. This is what the envelope buys.
+    #[test]
+    fn minimal_envelope_category_survives_dyn_erasure() {
+        use zencodec::decode::DynDecoderConfig;
+        use zencodec::{CodecError, CodecErrorExt, ErrorCategory};
+
+        // Drive the minimal codec entirely through the dyn surface; its
+        // `At<CodecError>` is erased to `Box<dyn Error>` by the shim.
+        let cfg = MinimalDecoderConfig::new();
+        let dyn_min: &dyn DynDecoderConfig = &cfg;
+        let erased = dyn_min
+            .dyn_job()
+            .probe(b"not a ZCR1 header")
+            .expect_err("malformed header must fail");
+        // A consumer holding only `Box<dyn Error>` recovers the category — and
+        // the originating codec name, so it can tell codecs apart generically.
+        assert_eq!(erased.error_category(), Some(ErrorCategory::MalformedImage));
+        assert_eq!(
+            erased.codec_error().and_then(CodecError::codec),
+            Some(crate::reference::MINIMAL_CODEC_NAME)
+        );
+
+        // Contrast: the reference codec (`type Error = RefError`) classifies fine
+        // on the *typed* path, but once dyn dispatch erases it there is no shared
+        // concrete type to downcast to — the gap the envelope closes.
+        let ref_cfg = ReferenceDecoderConfig;
+        let dyn_ref: &dyn DynDecoderConfig = &ref_cfg;
+        let erased_ref = dyn_ref
+            .dyn_job()
+            .probe(b"not a ZCR1 header")
+            .expect_err("malformed header must fail");
+        assert_eq!(erased_ref.error_category(), None);
+        assert!(erased_ref.codec_error().is_none());
+    }
+
+    /// On the typed path, `At<CodecError>` answers the category two ways — the
+    /// total inherent `category()` on the envelope and the `Option` recovery —
+    /// and carries a location trace (the `From` bridge starts it).
+    #[test]
+    fn minimal_envelope_typed_path_and_trace() {
+        use std::borrow::Cow;
+        use zencodec::decode::{DecodeJob, DecoderConfig};
+        use zencodec::{CodecErrorExt, ErrorCategory};
+
+        let err = MinimalDecoderConfig::new()
+            .job()
+            .decoder(Cow::Borrowed(b"not a ZCR1 header"), &[])
+            .expect_err("malformed header must fail");
+        // Total category + codec name via the concrete envelope:
+        assert_eq!(err.error().category(), ErrorCategory::MalformedImage);
+        assert_eq!(
+            err.error().codec(),
+            Some(crate::reference::MINIMAL_CODEC_NAME)
+        );
+        // Same category via the generic Option recovery:
+        assert_eq!(err.error_category(), Some(ErrorCategory::MalformedImage));
+        // The trace was started by the bridge's `.start_at()`.
+        let dbg = format!("{err:?}");
+        assert!(dbg.contains("at "), "expected a trace frame: {dbg}");
+    }
+
     /// The minimal codec declares every optional capability *false* and rejects
     /// those paths, so the false-direction branches must all pass.
     #[test]

--- a/zencodec-testkit/src/minimal.rs
+++ b/zencodec-testkit/src/minimal.rs
@@ -4,26 +4,46 @@
 //! It exists so the testkit can validate the *false-direction* branches of
 //! [`check_capability_honesty`](crate::check_capability_honesty) against a
 //! known-correct "supports nothing extra" codec — the mirror of the full
-//! [`reference`](crate::reference) codec, which exercises the true branches. It
-//! shares the reference's wire format and error type, and reuses the reference's
-//! executor types for the associated types it never constructs (it rejects those
-//! paths before building them).
+//! [`reference`](crate::reference) codec, which exercises the true branches.
+//!
+//! It also demonstrates the **envelope error pattern**: `type Error =
+//! At<CodecError>`. A generic consumer recovers the
+//! [`ErrorCategory`](zencodec::ErrorCategory) from a type-erased
+//! `Box<dyn Error>` — e.g. the `BoxedError` left after dyn dispatch — by
+//! downcasting to the concrete `At<CodecError>`. That is the contrast with
+//! [`reference`](crate::reference), whose `type Error = RefError` only
+//! classifies on the *typed* path: once erased, all you hold is a `dyn Error`,
+//! not a `dyn CategorizedError`, so there is no concrete type to downcast to.
+//!
+//! Adoption cost is one impl: it shares the reference's wire format and its
+//! [`RefError`] kind, bridged by `From<RefError> for At<CodecError>`, so every
+//! `?` on a `Result<_, RefError>` auto-wraps into the envelope with no rewrite.
+//! Rejected decode modes use the generic [`Unsupported`] stub.
 
 use std::borrow::Cow;
 
+use whereat::At;
 use zencodec::decode::{
     Decode, DecodeCapabilities, DecodeJob, DecodeOutput, DecodeRowSink, DecoderConfig, OutputInfo,
+    SinkError,
 };
 use zencodec::encode::{EncodeCapabilities, EncodeJob, EncodeOutput, Encoder, EncoderConfig};
 use zencodec::{
-    ImageFormat, ImageInfo, Metadata, Orientation, ResourceLimits, StopToken, UnsupportedOperation,
+    CodecError, ImageFormat, ImageInfo, Metadata, Orientation, ResourceLimits, StopToken,
+    Unsupported, UnsupportedOperation,
 };
 use zenpixels::{PixelBuffer, PixelDescriptor, PixelSlice};
 
 use crate::reference::{
-    Header, RefAnimDec, RefError, RefStreamDec, build_info, descriptor_for_bpp, encode_single,
-    frame_pixel_len, frame_pixels_offset, parse_header,
+    Header, RefError, build_info, descriptor_for_bpp, encode_single, frame_pixel_len,
+    frame_pixels_offset, parse_header,
 };
+
+/// Bridge a decode-sink error into the envelope. `copy_decode_to_sink` wants a
+/// `fn` pointer, so this is a named function rather than a closure.
+fn wrap_sink(e: SinkError) -> At<CodecError> {
+    RefError::Sink(e).into()
+}
 
 // Only the always-available capabilities are declared. Everything optional —
 // push_rows, encode_from, animation, lossless, stop, icc/exif/xmp/cicp — is
@@ -49,7 +69,7 @@ impl MinimalEncoderConfig {
 }
 
 impl EncoderConfig for MinimalEncoderConfig {
-    type Error = RefError;
+    type Error = At<CodecError>;
     type Job = MinEncodeJob;
 
     fn format() -> ImageFormat {
@@ -74,12 +94,12 @@ pub struct MinEncodeJob {
 }
 
 impl EncodeJob for MinEncodeJob {
-    type Error = RefError;
+    type Error = At<CodecError>;
     type Enc = MinEnc;
     // `()` is the standard rejection stub for a still-only codec (the shape real
     // codecs use). It also pins the testkit's animation bounds to NOT require
     // `AnimationFrameEnc::Error == E::Error` — `<() as AnimationFrameEncoder>::Error`
-    // is `UnsupportedOperation`, not `RefError`.
+    // is `UnsupportedOperation`, not the job's error.
     type AnimationFrameEnc = ();
 
     fn with_stop(self, _stop: StopToken) -> Self {
@@ -94,13 +114,13 @@ impl EncodeJob for MinEncodeJob {
         self.orientation = meta.orientation;
         self
     }
-    fn encoder(self) -> Result<MinEnc, RefError> {
+    fn encoder(self) -> Result<MinEnc, At<CodecError>> {
         Ok(MinEnc {
             orientation: self.orientation,
         })
     }
-    fn animation_frame_encoder(self) -> Result<(), RefError> {
-        Err(RefError::Unsupported(UnsupportedOperation::AnimationEncode))
+    fn animation_frame_encoder(self) -> Result<(), At<CodecError>> {
+        Err(RefError::Unsupported(UnsupportedOperation::AnimationEncode).into())
     }
 }
 
@@ -111,13 +131,13 @@ pub struct MinEnc {
 }
 
 impl Encoder for MinEnc {
-    type Error = RefError;
+    type Error = At<CodecError>;
 
-    fn reject(op: UnsupportedOperation) -> RefError {
-        RefError::Unsupported(op)
+    fn reject(op: UnsupportedOperation) -> At<CodecError> {
+        RefError::Unsupported(op).into()
     }
 
-    fn encode(self, pixels: PixelSlice<'_>) -> Result<EncodeOutput, RefError> {
+    fn encode(self, pixels: PixelSlice<'_>) -> Result<EncodeOutput, At<CodecError>> {
         // Orientation only — no metadata channels.
         let meta = Metadata::none().with_orientation(self.orientation);
         Ok(EncodeOutput::new(
@@ -143,7 +163,7 @@ impl MinimalDecoderConfig {
 }
 
 impl DecoderConfig for MinimalDecoderConfig {
-    type Error = RefError;
+    type Error = At<CodecError>;
     type Job<'a> = MinDecodeJob;
 
     fn formats() -> &'static [ImageFormat] {
@@ -164,11 +184,12 @@ impl DecoderConfig for MinimalDecoderConfig {
 pub struct MinDecodeJob;
 
 impl<'a> DecodeJob<'a> for MinDecodeJob {
-    type Error = RefError;
+    type Error = At<CodecError>;
     type Dec = MinDec<'a>;
-    // Never constructed — streaming/animation are declared false and rejected.
-    type StreamDec = RefStreamDec<'a>;
-    type AnimationFrameDec = RefAnimDec;
+    // Streaming / animation are declared false and rejected before any stub is
+    // built, so the generic `Unsupported` stub (Error = the job's error) suffices.
+    type StreamDec = Unsupported<At<CodecError>>;
+    type AnimationFrameDec = Unsupported<At<CodecError>>;
 
     fn with_stop(self, _stop: StopToken) -> Self {
         self
@@ -177,11 +198,11 @@ impl<'a> DecodeJob<'a> for MinDecodeJob {
         self
     }
 
-    fn probe(&self, data: &[u8]) -> Result<ImageInfo, RefError> {
+    fn probe(&self, data: &[u8]) -> Result<ImageInfo, At<CodecError>> {
         Ok(build_info(&parse_header(data)?))
     }
 
-    fn output_info(&self, data: &[u8]) -> Result<OutputInfo, RefError> {
+    fn output_info(&self, data: &[u8]) -> Result<OutputInfo, At<CodecError>> {
         let h = parse_header(data)?;
         Ok(OutputInfo::full_decode(
             h.width,
@@ -194,7 +215,7 @@ impl<'a> DecodeJob<'a> for MinDecodeJob {
         self,
         data: Cow<'a, [u8]>,
         _preferred: &[PixelDescriptor],
-    ) -> Result<MinDec<'a>, RefError> {
+    ) -> Result<MinDec<'a>, At<CodecError>> {
         parse_header(&data)?;
         Ok(MinDec { data })
     }
@@ -204,24 +225,24 @@ impl<'a> DecodeJob<'a> for MinDecodeJob {
         data: Cow<'a, [u8]>,
         sink: &mut dyn DecodeRowSink,
         preferred: &[PixelDescriptor],
-    ) -> Result<OutputInfo, RefError> {
-        zencodec::helpers::copy_decode_to_sink(self, data, sink, preferred, RefError::Sink)
+    ) -> Result<OutputInfo, At<CodecError>> {
+        zencodec::helpers::copy_decode_to_sink(self, data, sink, preferred, wrap_sink)
     }
 
     fn streaming_decoder(
         self,
         _data: Cow<'a, [u8]>,
         _preferred: &[PixelDescriptor],
-    ) -> Result<RefStreamDec<'a>, RefError> {
-        Err(RefError::Unsupported(UnsupportedOperation::RowLevelDecode))
+    ) -> Result<Unsupported<At<CodecError>>, At<CodecError>> {
+        Err(RefError::Unsupported(UnsupportedOperation::RowLevelDecode).into())
     }
 
     fn animation_frame_decoder(
         self,
         _data: Cow<'a, [u8]>,
         _preferred: &[PixelDescriptor],
-    ) -> Result<RefAnimDec, RefError> {
-        Err(RefError::Unsupported(UnsupportedOperation::AnimationDecode))
+    ) -> Result<Unsupported<At<CodecError>>, At<CodecError>> {
+        Err(RefError::Unsupported(UnsupportedOperation::AnimationDecode).into())
     }
 }
 
@@ -232,9 +253,9 @@ pub struct MinDec<'a> {
 }
 
 impl Decode for MinDec<'_> {
-    type Error = RefError;
+    type Error = At<CodecError>;
 
-    fn decode(self) -> Result<DecodeOutput, RefError> {
+    fn decode(self) -> Result<DecodeOutput, At<CodecError>> {
         let h: Header = parse_header(&self.data)?;
         let desc = descriptor_for_bpp(h.bpp)?;
         let start = frame_pixels_offset(&h, 0);

--- a/zencodec-testkit/src/reference.rs
+++ b/zencodec-testkit/src/reference.rs
@@ -25,6 +25,7 @@
 use std::borrow::Cow;
 
 use enough::{Stop, StopReason};
+use whereat::At;
 use zencodec::decode::{
     AnimationFrameDecoder, Decode, DecodeCapabilities, DecodeJob, DecodeOutput, DecodeRowSink,
     DecoderConfig, OutputInfo, SinkError, StreamingDecode,
@@ -33,8 +34,9 @@ use zencodec::encode::{
     AnimationFrameEncoder, EncodeCapabilities, EncodeJob, EncodeOutput, Encoder, EncoderConfig,
 };
 use zencodec::{
-    AnimationFrame, Cicp, ImageFormat, ImageInfo, ImageSequence, Metadata, Orientation,
-    ResourceLimits, StopToken, UnsupportedOperation,
+    AnimationFrame, CategorizedError, Cicp, CodecError, CodecIoKind, ErrorCategory, ImageFormat,
+    ImageInfo, ImageSequence, Metadata, Orientation, ResourceLimits, StopToken,
+    UnsupportedOperation,
 };
 use zenpixels::{PixelBuffer, PixelDescriptor, PixelSlice};
 
@@ -49,7 +51,8 @@ pub enum RefError {
     Unsupported(UnsupportedOperation),
     /// Malformed wire data.
     Invalid(String),
-    /// Cooperative cancellation fired.
+    /// Cooperative cancellation fired. The [`CategorizedError`] impl maps it
+    /// (and a timeout) to the right [`ErrorCategory`] without naming `RefError`.
     Cancelled(StopReason),
     /// A resource limit was exceeded.
     Limit(zencodec::LimitExceeded),
@@ -75,7 +78,8 @@ impl std::error::Error for RefError {
             Self::Unsupported(e) => Some(e),
             Self::Limit(e) => Some(e),
             Self::Sink(e) => Some(e.as_ref()),
-            _ => None,
+            // StopReason is not an Error, so cancellation isn't a source link.
+            Self::Cancelled(_) | Self::Invalid(_) => None,
         }
     }
 }
@@ -90,11 +94,51 @@ impl From<StopReason> for RefError {
         Self::Cancelled(r)
     }
 }
+
+/// Opt into the codec-agnostic error taxonomy: map each variant to a category,
+/// delegating to the zencodec cause types where they apply.
+impl CategorizedError for RefError {
+    fn codec_name(&self) -> Option<&'static str> {
+        Some(MINIMAL_CODEC_NAME)
+    }
+    fn category(&self) -> ErrorCategory {
+        match self {
+            Self::Unsupported(e) => e.category(),
+            Self::Invalid(_) => ErrorCategory::MalformedImage,
+            Self::Cancelled(r) => r.category(),
+            Self::Limit(e) => e.category(),
+            Self::Sink(_) => ErrorCategory::Io(CodecIoKind::opaque()),
+        }
+    }
+}
 impl From<zencodec::LimitExceeded> for RefError {
     fn from(e: zencodec::LimitExceeded) -> Self {
         Self::Limit(e)
     }
 }
+
+/// The one-impl bridge a codec adds to return the shared envelope as
+/// `At<CodecError>` (the [`minimal`](crate::minimal) codec does this; the
+/// [`reference`](crate::reference) keeps the simpler `type Error = RefError`).
+///
+/// `.start_at()` begins the location trace; `CodecError::of` then takes that
+/// `At<RefError>` and maps it to `At<CodecError>`, keeping the trace on the
+/// outside and reading the category *and* codec name
+/// ([`RefError::codec_name`](CategorizedError::codec_name)) from the value. With
+/// this in place, `?` on any `Result<_, RefError>` auto-wraps into
+/// `At<CodecError>`, so existing fallible internals need no rewrite.
+impl From<RefError> for At<CodecError> {
+    #[track_caller]
+    fn from(e: RefError) -> Self {
+        use whereat::ErrorAtExt;
+        CodecError::of(e.start_at())
+    }
+}
+
+/// Codec name the envelope reports (via [`RefError`]'s `codec_name`). The only
+/// consumer of the bridge is the [`minimal`](crate::minimal) codec (the
+/// `reference` returns `RefError` directly), so it names that codec.
+pub(crate) const MINIMAL_CODEC_NAME: &str = "zencodec-testkit/minimal";
 
 // ===========================================================================
 // Wire format


### PR DESCRIPTION
Closes #99.

## What & why

#99 asked to classify *cancellation* generically. Rather than accrete a cancellation-specific extractor, this adds a **unified, codec-agnostic error taxonomy** plus a shared envelope, so a consumer can route *any* codec error (HTTP status, retry, logging) with one `match` — and recover that classification even after the error is type-erased through dyn dispatch or `anyhow`.

Everything here is **additive** — `cargo-semver-checks` reports no break vs the released `0.1.25`.

## `ErrorCategory` (`#[non_exhaustive]`, `Copy`) + `CategorizedError`

17 categories, distilled from an inventory of every zen codec's error enum (see [`docs/error-taxonomy-inventory.md`](docs/error-taxonomy-inventory.md)):

`MalformedImage`, `UnexpectedEof`, `UnsupportedImageType`, `UnsupportedImageFeature`, `UnsupportedPixelFormat`, `UnsupportedOperation`, `CmsRequired`, `PolicyRejected`, `Cancelled`, `TimedOut`, `LimitsExceeded(LimitKind)`, `OutOfMemory`, `Io`, `InvalidParameters`, `InvalidBuffer`, `InvalidState`, `Internal`.

```rust
trait CategorizedError {
    const CODEC_NAME: &'static str = "";   // a codec declares its name here; cause types keep ""
    fn category(&self) -> ErrorCategory;
}
```

**Opt-in** — a codec implements it on its error type, mapping each variant to one category and declaring its name once via `CODEC_NAME`. It is *not* in the `EncoderConfig`/`DecoderConfig::Error` bound, so adopting it breaks nothing. A blanket `impl<E: CategorizedError> CategorizedError for whereat::At<E>` forwards both through the location wrapper. zencodec's own cause types implement it (`LimitExceeded` → `LimitsExceeded(kind)`, `UnsupportedOperation`, `enough::StopReason` → `Cancelled`/`TimedOut`; they keep the `""` name), so a codec's mapping is usually a one-line delegation per arm. Adds `LimitKind` (the value-free discriminant of `LimitExceeded`).

## `CodecError` — the envelope that survives erasure

`CategorizedError` classifies on the *typed* path, but once an error is erased to `Box<dyn Error>` (e.g. after dyn dispatch) you can't downcast to `dyn CategorizedError`, so the category is lost. `CodecError` is the carrier that closes that gap:

```rust
struct CodecError { category, codec: &'static str (thin), detail: Option<…> }
```

A codec returns it as **`whereat::At<CodecError>`** — a single *concrete* type, so a consumer recovers the category **and** the originating codec name from any `Box<dyn Error>` / `anyhow::Error` / mapped wrapper by downcast:

- `CodecError::of(native_err)` captures **both** the category and the codec name from the detail's `CategorizedError` impl — no codec argument. `new(&"zenjpeg", category)` is a complete error with *no detail* (for a codec with no error enum of its own); `from_parts(…)` takes an explicit category + name.
- `CodecErrorExt::codec_error() -> Option<&CodecError>` recovers the envelope (category + codec + detail); `error_category()` is the shortcut. Both defaulted, so additive.
- `Display` is `"{codec}: {detail-or-category}"`; `source()` is the detail, so the typed extractors (`limit_exceeded`, `find_cause::<T>`, …) still reach the underlying cause.

**Small in `Result`.** The codec name is stored as a thin `&'static &'static str` (1 word, not the 2 a `&str` costs — `of` stores `&E::CODEC_NAME`, which promotes), so `CodecError` is 4 words (32 B on 64-bit) and `Result<_, At<CodecError>>` — what every codec signature threads through `?` — is 5 words (40 B), down from 48 with a `&str` inline. Unboxed, so `new` is `const` and detail-free errors don't allocate. A word-relative `error_types_stay_small` test guards it (holds on 32-bit too).

**Want 8 bytes?** A size-sensitive codec can use `type Error = Box<At<CodecError>>` (one pointer) and **unbox internally**: keep internal fns returning `At<CodecError>` (clean `?` / `.at()`), and `?` re-boxes at the trait boundary (`Box<At<CodecError>>: From<At<CodecError>>`). Recovery probes a single `Box` layer (`Box<At<CodecError>>` / `At<Box<CodecError>>` / `Box<CodecError>`), so the boxed form stays classifiable (`recovery_tolerates_a_single_box_layer`).

## `StreamOffset` + `whereat` re-export

- `StreamOffset(pub u64)` — a shared, downcast-able newtype for *where in the encoded input* a decode failed. A codec attaches it to the trace with `.at_data(|| StreamOffset(pos))`; a consumer recovers it via `err.contexts().find_map(|c| c.downcast_ref::<StreamOffset>())`, even after erasure. Per-variant detail stays in the native error; richer loci (marker / box fourcc / NAL / frame index) ride the same `at_data` channel.
- Re-exports `whereat::{At, ErrorAtExt, ResultAtExt}` (+ `pub use whereat;`) so a codec names `zencodec::At<zencodec::CodecError>` and reaches `start_at()` / `.at()` without a direct `whereat` dependency. No new coupling — `At` was already public via the blanket `impl CategorizedError for At<E>`.

## Adoption (one impl per codec)

```rust
impl CategorizedError for MyError {
    const CODEC_NAME: &'static str = "mycodec";
    fn category(&self) -> ErrorCategory { /* match variants */ }
}
impl From<MyError> for At<CodecError> {
    fn from(e: MyError) -> Self { CodecError::of(e).start_at() }
}
```

After this, `?` auto-wraps any `Result<_, MyError>` into the envelope — existing fallible internals need no rewrite. Reject stubs use `Unsupported<At<CodecError>>`.

## Routing example

```rust
let http = match err.error_category() {                  // Option<ErrorCategory>, recovered post-erasure
    Some(ErrorCategory::Cancelled)            => 499,
    Some(ErrorCategory::TimedOut)             => 504,
    Some(ErrorCategory::LimitsExceeded(_))    => 413,
    Some(ErrorCategory::PolicyRejected)       => 422,
    Some(ErrorCategory::UnsupportedImageType
        | ErrorCategory::UnsupportedImageFeature
        | ErrorCategory::UnsupportedPixelFormat
        | ErrorCategory::UnsupportedOperation
        | ErrorCategory::CmsRequired)         => 415,
    Some(ErrorCategory::MalformedImage
        | ErrorCategory::UnexpectedEof
        | ErrorCategory::InvalidParameters
        | ErrorCategory::InvalidBuffer)       => 400,
    _                                         => 500,     // resource / IO / state / bug / non-codec
};
```

## Conformance demonstration

The testkit contrasts both patterns end-to-end:
- **`reference`** keeps `type Error = RefError` (native enum + `CategorizedError`) — classification on the typed path.
- **`minimal`** uses `type Error = At<CodecError>` (the envelope). `minimal_envelope_category_survives_dyn_erasure` drives it through the dyn surface and recovers the category **and** codec name from the resulting `BoxedError` — and asserts the native-enum `reference` returns `None` once erased, the exact gap the envelope closes.

## Status

Verified locally and on CI (all 13 jobs: Linux x64/aarch64, Windows x64/arm64, macOS x64/arm64, i686, WASM `wasm32-wasip1`, MSRV 1.88, clippy, fmt, semver, doc): `cargo test --workspace` (532 + testkit + doctests), `clippy --all-targets`, `fmt --check`, `cargo doc -D warnings`, `cargo-semver-checks` (no break vs 0.1.25). Release bumps `0.1.25 → 0.1.26` (additive) at merge.
