### PR TITLE
feat(error)!: two-level origin-first ErrorCategory (Image/Request/Resource/Policy/Lifecycle/Io/Internal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ All notable changes to zencodec are documented here.
   (`Limits(LimitKind)` / `OutOfMemory`), `Policy(PolicyKind)` (valid input a
   configured policy declined — `PolicyKind::{Decode,Encode}` mirrors the crate's
   existing `DecodePolicy`/`EncodePolicy` split, so the call site already knows
-  which one), `Lifecycle(enough::StopReason)` (stopped via the `Stop` token — the
+  which one), `Stopped(enough::StopReason)` (stopped via the `Stop` token — the
   reason *is* the payload, no re-derived enum), `Io(CodecIoKind)`, and
   `Internal(InternalKind)` (`InternalKind::Bug` — a broken invariant in the
   codec's own logic, never retryable — vs `InternalKind::Dependency` — an
@@ -98,7 +98,7 @@ All notable changes to zencodec are documented here.
   non-codec cause types. A blanket impl forwards through `whereat::At<E>` so a
   located error keeps its category; zencodec's own cause types implement it
   (`LimitExceeded` → `Resource(Limits(kind))`, `UnsupportedOperation` →
-  `Request(Unsupported(self))`, `enough::StopReason` → `Lifecycle(self)` — a
+  `Request(Unsupported(self))`, `enough::StopReason` → `Stopped(self)` — a
   direct passthrough, not a lossy remap), making a codec's mapping a one-line
   delegation per arm.
   Adds `LimitKind` (the value-free discriminant of `LimitExceeded`, via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,35 +62,68 @@ All notable changes to zencodec are documented here.
 - **Unified error taxonomy: `ErrorCategory` enum + `CategorizedError` trait** —
   a codec-agnostic way to classify any codec error for routing (HTTP status,
   retry, logging) without naming the concrete enum (zencodec#99, superseding the
-  cancellation-only sketch). `ErrorCategory` (`#[non_exhaustive]`, `Copy`):
-  `MalformedImage`, `UnexpectedEof`, `UnsupportedImageType`,
-  `UnsupportedImageFeature`, `UnsupportedPixelFormat`, `UnsupportedOperation`,
-  `CmsRequired`, `PolicyRejected`, `Cancelled`, `TimedOut`,
-  `LimitsExceeded(LimitKind)`, `OutOfMemory`, `Io`, `InvalidParameters`,
-  `InvalidBuffer`, `InvalidState`, `Internal` — the set distilled from an
-  inventory of every zen codec's error enum (the "unsupported" axis splits into
-  type / image-feature / pixel-format-negotiation / API-operation; `CmsRequired`
-  covers e.g. zenwebp's ICC-synthesis-unavailable; `PolicyRejected` covers valid
-  input a configured policy declined, e.g. zenjxl's progressive-rejected;
-  `InvalidBuffer` is a wrong-geometry pixel buffer and `InvalidState` is API
-  misuse / wrong-sequence). `CategorizedError: Any { fn codec_name(&self) ->
-  Option<&'static str>; fn category(&self) -> ErrorCategory }` is **opt-in** (not
-  blanket-impl'd, not added to the `Error` bound), so adopting it is additive and
-  back-compatible. The `Any` supertrait keeps a `dyn CategorizedError` downcastable
-  (both methods take `&self`, so the trait is dyn-compatible); `codec_name()` is
-  required, returning `None` for the non-codec cause types. A blanket impl forwards
-  through `whereat::At<E>` so a located error keeps its category;
-  zencodec's own cause types implement it (`LimitExceeded` →
-  `LimitsExceeded(kind)`, `UnsupportedOperation` → `UnsupportedOperation` /
-  `UnsupportedPixelFormat`, `enough::StopReason` → `Cancelled`/`TimedOut`), making
-  a codec's mapping a one-line delegation per arm.
+  cancellation-only sketch). `ErrorCategory` (`#[non_exhaustive]`, `Copy`) is
+  **origin-first, two-level**: `Image(ImageError)` (the bytes are the problem —
+  `Malformed` / `UnexpectedEof` / `Unsupported(UnsupportedImageKind::{Type,
+  Feature})`), `Request(RequestError)` (the caller's request is the problem —
+  `Invalid(InvalidKind::{Parameters,Buffer,State})` /
+  `Unsupported(UnsupportedOperation)` / `CmsRequired`), `Resource(ResourceError)`
+  (`Limits(LimitKind)` / `OutOfMemory`), `Policy(PolicyKind)` (valid input a
+  configured policy declined — `PolicyKind::{Decode,Encode}` mirrors the crate's
+  existing `DecodePolicy`/`EncodePolicy` split, so the call site already knows
+  which one), `Lifecycle(enough::StopReason)` (stopped via the `Stop` token — the
+  reason *is* the payload, no re-derived enum), `Io(CodecIoKind)`, and
+  `Internal(InternalKind)` (`InternalKind::Bug` — a broken invariant in the
+  codec's own logic, never retryable — vs `InternalKind::Dependency` — an
+  unclassified error surfaced from a sub-component/foreign library; both still
+  mean "500" for routing, the split is for telemetry/triage: it lets a generic
+  consumer that only carries the category forward, without a per-codec downcast,
+  tell "we have a code defect" from "we have a classification gap" from
+  production traffic). The set is distilled from an inventory of every zen codec's
+  error enum, then reshaped so the top level answers "who owns the fault" before
+  any sub-kind: `Image` is untouchable by the caller (a *different* codec might
+  handle the bytes); `Request` is the caller's to fix. This is also what makes
+  the whole `Image(_)` arm exactly the incomplete-input-tolerable set for
+  `zencodec-testkit::check_decode_truncation_series` (zencodec#112) — one
+  `matches!(cat, ErrorCategory::Image(_))` instead of enumerating four flat
+  variants. Sub-enums carry `From` shortcuts into `ErrorCategory` (and the leaf
+  kinds `UnsupportedImageKind` / `InvalidKind` / `LimitKind` shortcut into their
+  parent too), so a codec's `category()` arm reads `ImageError::Malformed.into()`
+  rather than spelling the outer wrapper. `CategorizedError: Any { fn
+  codec_name(&self) -> Option<&'static str>; fn category(&self) -> ErrorCategory
+  }` is **opt-in** (not blanket-impl'd, not added to the `Error` bound), so
+  adopting it is additive and back-compatible. The `Any` supertrait keeps a `dyn
+  CategorizedError` downcastable (both methods take `&self`, so the trait is
+  dyn-compatible); `codec_name()` is required, returning `None` for the
+  non-codec cause types. A blanket impl forwards through `whereat::At<E>` so a
+  located error keeps its category; zencodec's own cause types implement it
+  (`LimitExceeded` → `Resource(Limits(kind))`, `UnsupportedOperation` →
+  `Request(Unsupported(self))`, `enough::StopReason` → `Lifecycle(self)` — a
+  direct passthrough, not a lossy remap), making a codec's mapping a one-line
+  delegation per arm.
   Adds `LimitKind` (the value-free discriminant of `LimitExceeded`, via
-  `LimitExceeded::kind()`). No new dependencies. The testkit `reference` codec
-  adopts the trait; `reference_cancellation_is_classifiable` proves end-to-end
-  classification through a real cancelled operation. The category set is backed
-  by a per-codec error inventory + right-sizing analysis in
+  `LimitExceeded::kind()`) plus two structural variants with no corresponding
+  `LimitExceeded` payload: `Scans` (a progressive-decode scan-count ceiling) and
+  `DecompressionRatio` (a compression-bomb ceiling, security-relevant — distinct
+  from an absolute `Memory` cap). No new dependencies. The testkit `reference`
+  codec adopts the trait; `reference_cancellation_is_classifiable` proves
+  end-to-end classification through a real cancelled operation. The category set
+  is backed by a per-codec error inventory + right-sizing analysis in
   `docs/error-taxonomy-inventory.md` (with `docs/error-types-ecosystem.md`
-  surveying the surrounding crates).
+  surveying the surrounding crates) — both carry a superseded-shape note pointing
+  at this reshape and `docs/spec.md` for the current form.
+- **zencodec-testkit: `check_decode_truncation_series` EOF/truncation conformance
+  check** (zencodec#112) — feeds a known-good encoded image, builds a
+  deterministic series of truncation lengths (small absolute header sizes unioned
+  with fractions of the full length), and for each prefix runs a **full decode
+  through the dyn-erased boundary** (`DynDecodeJob::push_decode` into a throwaway
+  sink — so pixel-body truncation is exercised, not just what a `probe` reads).
+  Asserts every resulting `ErrorCategory` is in the allowed incomplete-input set
+  via the new `is_incomplete_input_category` (see the taxonomy reshape above —
+  the whole `Image(_)` arm). Catches the real bug class where a codec reads a
+  length field out of truncated data and OOMs, or funnels a truncation into
+  `Internal` (5xx for what should read as a 4xx client error) — exactly the
+  misattribution the origin-first taxonomy exists to make checkable in one line.
 - **`CodecError` envelope + `CodecErrorExt::{codec_error, error_category}`** — the
   carrier that makes a category (and the originating codec) survive **type
   erasure**, the gap `CategorizedError` alone can't close (after erasure you hold a

--- a/README.md
+++ b/README.md
@@ -202,36 +202,50 @@ A codec surfaces errors one of two ways; both let you route on a coarse
   be recovered once erased — the erased value is a `dyn Error`, not a
   `dyn CategorizedError` — so the envelope is what a codec-agnostic pipeline reaches
   for. `CodecError` can also be used with no detail at all
-  (`CodecError::new(Some("zenpng"), ErrorCategory::MalformedImage)`) by a codec that
+  (`CodecError::new(Some("zenpng"), ErrorCategory::Image(ImageError::Malformed))`) by a codec that
   has no error enum of its own. `At` is re-exported
   (`zencodec::At<zencodec::CodecError>`), so adopting it needs no direct `whereat`
   dependency.
 
 ```rust,ignore
-use zencodec::{CategorizedError, CodecErrorExt, ErrorCategory};
+use zencodec::enough::StopReason;
+use zencodec::{
+    CategorizedError, CodecErrorExt, ErrorCategory, ImageError, InvalidKind, RequestError,
+    ResourceError,
+};
 
 // Typed path shown here via `category()`; on a `Box<dyn Error>` from dyn dispatch
-// use `e.error_category()` and match `Some(..)` / `None` instead.
+// use `e.error_category()` and match `Some(..)` / `None` instead. The origin-first
+// shape lets you route on the outer arm (`Image` / `Request` / `Resource` /
+// `Lifecycle`) and only destructure when a sub-kind changes the answer.
 let http = match config.job().with_stop(token).decoder(Cow::Borrowed(bytes), &[]) {
     Ok(_decoder) => { /* _decoder.decode()? */ 200 }
     Err(e) => match e.category() {
-        ErrorCategory::Cancelled            => 499, // client went away
-        ErrorCategory::TimedOut             => 504,
-        ErrorCategory::LimitsExceeded(_)    => 413,
-        ErrorCategory::UnsupportedImageType
-        | ErrorCategory::UnsupportedImageFeature
-        | ErrorCategory::UnsupportedPixelFormat
-        | ErrorCategory::UnsupportedOperation
-        | ErrorCategory::CmsRequired        => 415, // can't process this input/request
-        ErrorCategory::PolicyRejected       => 422, // valid, but a policy declined it
-        ErrorCategory::MalformedImage
-        | ErrorCategory::UnexpectedEof
-        | ErrorCategory::InvalidParameters
-        | ErrorCategory::InvalidBuffer      => 400, // the bytes / request are bad
-        ErrorCategory::OutOfMemory
+        // Lifecycle — the operation was stopped via its Stop token.
+        ErrorCategory::Lifecycle(StopReason::Cancelled) => 499, // client went away
+        ErrorCategory::Lifecycle(StopReason::TimedOut)  => 504,
+        // A configured resource cap was hit.
+        ErrorCategory::Resource(ResourceError::Limits(_)) => 413,
+        // "Can't process this" — the bytes need a different codec, or the request
+        // asked for an op / pixel format / CMS transform this codec doesn't do.
+        ErrorCategory::Image(ImageError::Unsupported(_))
+        | ErrorCategory::Request(RequestError::Unsupported(_))
+        | ErrorCategory::Request(RequestError::CmsRequired) => 415,
+        // Valid input, but a policy declined it — Decode vs Encode only matters
+        // if you want to word the message differently; both are 422 here.
+        ErrorCategory::Policy(_) => 422,
+        // Bad client-supplied bytes (malformed / truncated), or a bad request.
+        ErrorCategory::Image(_) => 400,
+        ErrorCategory::Request(RequestError::Invalid(
+            InvalidKind::Parameters | InvalidKind::Buffer,
+        )) => 400,
+        // Server-side: API misuse (out-of-sequence call), OOM, I/O, or a bug.
+        // `Internal(Bug)` vs `Internal(Dependency)` both still read as 500 for
+        // HTTP purposes; the split pays off in telemetry, not routing.
+        ErrorCategory::Request(RequestError::Invalid(InvalidKind::State))
+        | ErrorCategory::Resource(ResourceError::OutOfMemory)
         | ErrorCategory::Io(_)
-        | ErrorCategory::InvalidState
-        | ErrorCategory::Internal           => 500, // server-side: resource, IO, bug, misuse
+        | ErrorCategory::Internal(_) => 500,
         _ => 500, // ErrorCategory is #[non_exhaustive]
     },
 };

--- a/README.md
+++ b/README.md
@@ -217,13 +217,13 @@ use zencodec::{
 // Typed path shown here via `category()`; on a `Box<dyn Error>` from dyn dispatch
 // use `e.error_category()` and match `Some(..)` / `None` instead. The origin-first
 // shape lets you route on the outer arm (`Image` / `Request` / `Resource` /
-// `Lifecycle`) and only destructure when a sub-kind changes the answer.
+// `Stopped`) and only destructure when a sub-kind changes the answer.
 let http = match config.job().with_stop(token).decoder(Cow::Borrowed(bytes), &[]) {
     Ok(_decoder) => { /* _decoder.decode()? */ 200 }
     Err(e) => match e.category() {
-        // Lifecycle — the operation was stopped via its Stop token.
-        ErrorCategory::Lifecycle(StopReason::Cancelled) => 499, // client went away
-        ErrorCategory::Lifecycle(StopReason::TimedOut)  => 504,
+        // Stopped via its Stop token.
+        ErrorCategory::Stopped(StopReason::Cancelled) => 499, // client went away
+        ErrorCategory::Stopped(StopReason::TimedOut)  => 504,
         // A configured resource cap was hit.
         ErrorCategory::Resource(ResourceError::Limits(_)) => 413,
         // "Can't process this" — the bytes need a different codec, or the request

--- a/docs/error-taxonomy-inventory.md
+++ b/docs/error-taxonomy-inventory.md
@@ -1,5 +1,23 @@
 # Codec error inventory → `ErrorCategory` mapping
 
+> **Superseded shape (2026-07-13).** `ErrorCategory` was reshaped from the flat
+> 17-variant set below into an **origin-first two-level** enum —
+> `Image(ImageError) / Request(RequestError) / Resource(ResourceError) / Policy /
+> Lifecycle(StopReason) / Io(CodecIoKind) / Internal`, with sub-enums
+> (`ImageError`, `RequestError`, `InvalidKind`, `UnsupportedImageKind`,
+> `ResourceError`) — before the 0.1.26 freeze. See [`spec.md`](spec.md#errorcategory-enum--categorizederror-trait)
+> for the current canonical shape. The old→new key: `MalformedImage`→`Image(Malformed)`,
+> `UnexpectedEof`→`Image(UnexpectedEof)`, `UnsupportedImageType/Feature`→
+> `Image(Unsupported(Type/Feature))`, `UnsupportedPixelFormat/Operation`→
+> `Request(Unsupported(op))`, `CmsRequired`→`Request(CmsRequired)`,
+> `InvalidParameters/Buffer/State`→`Request(Invalid(Parameters/Buffer/State))`,
+> `PolicyRejected`→`Policy`, `Cancelled/TimedOut`→`Lifecycle(StopReason)`,
+> `LimitsExceeded(k)`→`Resource(Limits(k))`, `OutOfMemory`→`Resource(OutOfMemory)`,
+> `Io`/`Internal` unchanged. The per-codec mapping table below is retained as the
+> **historical basis** for the category set (the audit that justified each
+> category); the per-codec `category()` maps themselves are being rewritten to
+> the two-level form in the codec crates (Phases 2–3 of the reshape).
+
 Point-in-time reference (snapshot **2026-06-24**) backing the
 [`ErrorCategory`](../src/error.rs) / `CategorizedError` design (issue #99). It
 records the **actual error enum of every zen image codec**, maps every variant

--- a/docs/error-taxonomy-inventory.md
+++ b/docs/error-taxonomy-inventory.md
@@ -3,7 +3,7 @@
 > **Superseded shape (2026-07-13).** `ErrorCategory` was reshaped from the flat
 > 17-variant set below into an **origin-first two-level** enum —
 > `Image(ImageError) / Request(RequestError) / Resource(ResourceError) / Policy /
-> Lifecycle(StopReason) / Io(CodecIoKind) / Internal`, with sub-enums
+> Stopped(StopReason) / Io(CodecIoKind) / Internal`, with sub-enums
 > (`ImageError`, `RequestError`, `InvalidKind`, `UnsupportedImageKind`,
 > `ResourceError`) — before the 0.1.26 freeze. See [`spec.md`](spec.md#errorcategory-enum--categorizederror-trait)
 > for the current canonical shape. The old→new key: `MalformedImage`→`Image(Malformed)`,
@@ -11,7 +11,7 @@
 > `Image(Unsupported(Type/Feature))`, `UnsupportedPixelFormat/Operation`→
 > `Request(Unsupported(op))`, `CmsRequired`→`Request(CmsRequired)`,
 > `InvalidParameters/Buffer/State`→`Request(Invalid(Parameters/Buffer/State))`,
-> `PolicyRejected`→`Policy`, `Cancelled/TimedOut`→`Lifecycle(StopReason)`,
+> `PolicyRejected`→`Policy`, `Cancelled/TimedOut`→`Stopped(StopReason)`,
 > `LimitsExceeded(k)`→`Resource(Limits(k))`, `OutOfMemory`→`Resource(OutOfMemory)`,
 > `Io`/`Internal` unchanged. The per-codec mapping table below is retained as the
 > **historical basis** for the category set (the audit that justified each

--- a/docs/error-types-ecosystem.md
+++ b/docs/error-types-ecosystem.md
@@ -1,5 +1,12 @@
 # Zen ecosystem error types (non-codec) — survey
 
+> **Note (2026-07-13).** `ErrorCategory` has since been reshaped into an
+> origin-first two-level enum (`Image / Request / Resource / Policy / Lifecycle /
+> Io / Internal` + sub-enums); flat variant names used below (`MalformedImage`,
+> `PolicyRejected`, …) map per the key in
+> [`error-taxonomy-inventory.md`](error-taxonomy-inventory.md). See
+> [`spec.md`](spec.md#errorcategory-enum--categorizederror-trait) for the current shape.
+
 Companion to [`error-taxonomy-inventory.md`](error-taxonomy-inventory.md)
 (which covers the image **codecs**). Point-in-time snapshot **2026-06-24** of the
 error types in the surrounding zen crates — pixel/colour, processing, pipeline,

--- a/docs/error-types-ecosystem.md
+++ b/docs/error-types-ecosystem.md
@@ -1,7 +1,7 @@
 # Zen ecosystem error types (non-codec) — survey
 
 > **Note (2026-07-13).** `ErrorCategory` has since been reshaped into an
-> origin-first two-level enum (`Image / Request / Resource / Policy / Lifecycle /
+> origin-first two-level enum (`Image / Request / Resource / Policy / Stopped /
 > Io / Internal` + sub-enums); flat variant names used below (`MalformedImage`,
 > `PolicyRejected`, …) map per the key in
 > [`error-taxonomy-inventory.md`](error-taxonomy-inventory.md). See

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -946,12 +946,23 @@ logging) without naming the concrete error enum.
 ```rust
 #[non_exhaustive]
 enum ErrorCategory {
-    MalformedImage, UnexpectedEof,
-    UnsupportedImageType, UnsupportedImageFeature, UnsupportedPixelFormat,
-    UnsupportedOperation, CmsRequired, PolicyRejected,
-    Cancelled, TimedOut, LimitsExceeded(LimitKind), OutOfMemory,
-    Io(CodecIoKind), InvalidParameters, InvalidBuffer, InvalidState, Internal,
+    Image(ImageError),        // the bytes are the problem
+    Request(RequestError),    // the caller's request is the problem
+    Resource(ResourceError),  // a cap was hit, or allocation failed
+    Policy(PolicyKind),        // valid input a configured policy declined
+    Lifecycle(StopReason),    // stopped via the Stop token (Cancelled / TimedOut)
+    Io(CodecIoKind),          // an I/O or output-sink failure
+    Internal(InternalKind),   // a bug / broken invariant / unclassified dependency error
 }
+
+#[non_exhaustive] enum ImageError { Malformed, UnexpectedEof, Unsupported(UnsupportedImageKind) }
+#[non_exhaustive] enum UnsupportedImageKind { Type, Feature }
+#[non_exhaustive] enum RequestError { Invalid(InvalidKind), Unsupported(UnsupportedOperation), CmsRequired }
+#[non_exhaustive] enum InvalidKind { Parameters, Buffer, State }
+#[non_exhaustive] enum ResourceError { Limits(LimitKind), OutOfMemory }
+#[non_exhaustive] enum PolicyKind { Decode, Encode }      // mirrors DecodePolicy / EncodePolicy
+#[non_exhaustive] enum InternalKind { Bug, Dependency }   // Bug = our defect; Dependency = unclassified foreign error
+// StopReason is enough::StopReason { Cancelled, TimedOut } — reused, not re-defined.
 
 trait CategorizedError: core::any::Any {
     fn codec_name(&self) -> Option<&'static str>;  // required; cause types return None
@@ -959,16 +970,36 @@ trait CategorizedError: core::any::Any {
 }
 ```
 
-The "unsupported" axis is split four ways: `UnsupportedImageType` (the format
-isn't handled at all), `UnsupportedImageFeature` (a bitstream feature within a
-handled format), `UnsupportedPixelFormat` (negotiation found no common
-`PixelDescriptor`), and `UnsupportedOperation` (the requested API operation).
-`CmsRequired` flags a colour-management transform the codec won't perform itself.
-`PolicyRejected` is valid input the codec *could* handle but a configured policy
-declined (e.g. progressive content rejected by a decode policy). `InvalidBuffer`
-is a wrong-geometry pixel buffer (size/stride/alignment/descriptor) and
-`InvalidState` is API misuse (called out of sequence) — both distinct from
-`InvalidParameters` (config/knobs). `Io` carries a `CodecIoKind` — a
+**Origin-first shape.** The top level splits by *who owns the fault*, so a generic
+consumer can route on the outer arm and only destructure when a sub-kind changes
+the answer. `Image(_)` is "the bytes are the problem" (a *different* codec might
+handle them; the caller can't fix it by changing parameters) — this whole arm is
+the client-supplied-data / incomplete-input set a truncation check tolerates.
+`Request(_)` is "the *request* is the problem" (the caller can change config,
+buffer, call sequence, or the operation/format asked for).
+
+The "unsupported" axis is split by origin: `Image(Unsupported(Type))` (the format
+isn't handled at all), `Image(Unsupported(Feature))` (a bitstream feature within a
+handled format), and — on the request side — `Request(Unsupported(op))` (an API
+operation this codec doesn't do, including its `PixelFormat` arm when negotiation
+found no common `PixelDescriptor`). `Request(CmsRequired)` flags a
+colour-management transform the codec won't perform itself.
+`Policy(kind)` is valid input the codec *could* handle but a configured policy
+declined — `PolicyKind` mirrors the crate's existing `DecodePolicy` / `EncodePolicy`
+split (e.g. progressive content rejected by a decode policy, or alpha removal
+forbidden by an encode policy), so the call site already knows which one.
+`Internal(kind)` splits similarly for telemetry/triage, not routing: `Bug` is a
+broken invariant in the codec's own logic (never retryable, always alert-worthy);
+`Dependency` is an error surfaced from a sub-component/foreign library the codec
+hasn't classified into `Image`/`Request`/`Resource` — an honest "unclassified",
+not a permanent home. Both `Internal` variants still mean "500" for routing; the
+split only pays off when telemetry carries the category forward without a
+per-codec downcast.
+`Request(Invalid(Buffer))` is a wrong-geometry pixel buffer
+(size/stride/alignment/descriptor) and `Request(Invalid(State))` is API misuse
+(called out of sequence) — both distinct from `Request(Invalid(Parameters))`
+(config/knobs). `Resource(Limits(kind))` is a configured cap; `Resource(OutOfMemory)`
+is genuine allocation exhaustion. `Io` carries a `CodecIoKind` — a
 `std::io::ErrorKind` when the `std` feature is enabled, empty under `no_std` (the
 variant shape is stable either way, so matching `Io(_)` is portable), anticipating
 a future `core::io::ErrorKind`.
@@ -977,16 +1008,22 @@ The set is distilled from a per-codec inventory; see
 variant→category mapping and right-sizing rationale, and
 [`error-types-ecosystem.md`](error-types-ecosystem.md) for the wider ecosystem.
 
+Sub-enums carry `From` shortcuts into `ErrorCategory` (`ImageError`, `RequestError`,
+`ResourceError`, `StopReason`, and the leaf kinds `UnsupportedImageKind` /
+`InvalidKind` / `LimitKind`), so a codec's `category()` arm reads
+`ImageError::Malformed.into()` or `InvalidKind::Buffer.into()` rather than spelling
+the outer wrapper each time.
+
 `CategorizedError` is **opt-in** (not blanket-implemented): a codec implements it
 on its error type, mapping each variant to one category. It is **not** required
 by the `EncoderConfig`/`DecoderConfig::Error` bound, so adopting it is additive
 and back-compatible. A blanket `impl<E: CategorizedError> CategorizedError for
 whereat::At<E>` forwards to the inner error, so a located error keeps its
 category. zencodec's own cause types implement it (`LimitExceeded` →
-`LimitsExceeded(kind)`, `UnsupportedOperation` → `UnsupportedOperation` /
-`UnsupportedPixelFormat` for its `PixelFormat` arm, `enough::StopReason` →
-`Cancelled`/`TimedOut`), so a codec's mapping is usually a one-line delegation
-per arm. `LimitKind` is the value-free discriminant of `LimitExceeded`
+`Resource(Limits(kind))`, `UnsupportedOperation` → `Request(Unsupported(self))`,
+`enough::StopReason` → `Lifecycle(self)` — the reason IS the payload, no lossy
+collapse), so a codec's mapping is usually a one-line delegation per arm.
+`LimitKind` is the value-free discriminant of `LimitExceeded`
 (`LimitExceeded::kind()`).
 
 The `codec_name()` method is where a codec declares its name —
@@ -1088,7 +1125,7 @@ downcast — no codec-specific type named:
 
 ```rust
 // codec, at the failure site (offset = bytes consumed):
-Err(at!(CodecError::new(Some("zenjpeg"), ErrorCategory::MalformedImage))
+Err(at!(CodecError::new(Some("zenjpeg"), ErrorCategory::Image(ImageError::Malformed)))
     .at_data(|| StreamOffset(reader.position())))
 
 // consumer, even after erasure to Box<dyn Error>:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -950,7 +950,7 @@ enum ErrorCategory {
     Request(RequestError),    // the caller's request is the problem
     Resource(ResourceError),  // a cap was hit, or allocation failed
     Policy(PolicyKind),        // valid input a configured policy declined
-    Lifecycle(StopReason),    // stopped via the Stop token (Cancelled / TimedOut)
+    Stopped(StopReason),    // stopped via the Stop token (Cancelled / TimedOut)
     Io(CodecIoKind),          // an I/O or output-sink failure
     Internal(InternalKind),   // a bug / broken invariant / unclassified dependency error
 }
@@ -1021,7 +1021,7 @@ and back-compatible. A blanket `impl<E: CategorizedError> CategorizedError for
 whereat::At<E>` forwards to the inner error, so a located error keeps its
 category. zencodec's own cause types implement it (`LimitExceeded` →
 `Resource(Limits(kind))`, `UnsupportedOperation` → `Request(Unsupported(self))`,
-`enough::StopReason` → `Lifecycle(self)` — the reason IS the payload, no lossy
+`enough::StopReason` → `Stopped(self)` — the reason IS the payload, no lossy
 collapse), so a codec's mapping is usually a one-line delegation per arm.
 `LimitKind` is the value-free discriminant of `LimitExceeded`
 (`LimitExceeded::kind()`).

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,60 +24,208 @@ use whereat::At;
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum ErrorCategory {
-    /// The encoded image is invalid or corrupt — bad bitstream content.
-    MalformedImage,
-    /// Input ended before a complete image could be read (truncated / insufficient).
-    UnexpectedEof,
-    /// The format / container / codec / profile itself is not handled at all
-    /// (e.g. "not a PNG", an unknown variant, an unsupported HEVC profile).
-    UnsupportedImageType,
-    /// The format *is* handled, but the bitstream uses a feature this codec
-    /// hasn't implemented (e.g. arithmetic-coded JPEG, an unsupported chunk).
-    UnsupportedImageFeature,
-    /// No acceptable pixel format: format negotiation found no common
-    /// [`PixelDescriptor`](zenpixels::PixelDescriptor) between what the caller
-    /// requested and what the codec can produce/accept without lossy conversion.
-    UnsupportedPixelFormat,
-    /// The requested *API operation* is not supported by this codec — the
-    /// [`UnsupportedOperation`] axis (animation, row-level, multi-image, …).
-    UnsupportedOperation,
-    /// The codec needs a colour-management transform / ICC profile it will not
-    /// perform itself (CMS is the caller's job) — e.g. an encode target whose
-    /// ICC profile cannot be synthesized. The caller must supply the transform.
-    CmsRequired,
+    /// The failure originates in the **image bytes** — corrupt, truncated, or a
+    /// well-formed image using a type/feature this codec doesn't implement. A
+    /// *different* codec might handle it; the caller can't fix it by changing
+    /// parameters. See [`ImageError`].
+    Image(ImageError),
+    /// The failure originates in the **caller's request** — invalid
+    /// config/buffer/call-sequence, or a well-formed request for an operation /
+    /// pixel format this codec doesn't support. The caller *can* change the
+    /// request. See [`RequestError`].
+    Request(RequestError),
+    /// A resource ceiling — a configured [`ResourceLimits`](crate::ResourceLimits)
+    /// cap, or genuine allocation exhaustion. See [`ResourceError`].
+    Resource(ResourceError),
     /// The input is valid and the codec *could* handle it, but a configured
-    /// policy refused it — e.g. a decode policy rejecting progressive content,
-    /// or a conversion policy forbidding alpha removal / depth reduction. The
-    /// request was understood and *declined*, so it is neither malformed nor
-    /// unsupported; often maps to HTTP 422.
-    PolicyRejected,
-    /// Cooperatively cancelled via the operation's [`Stop`](enough::Stop) token.
-    Cancelled,
-    /// The operation exceeded its deadline (a [`Stop`](enough::Stop) timeout).
-    TimedOut,
-    /// A [`ResourceLimits`](crate::ResourceLimits) cap was (or would be) exceeded.
-    LimitsExceeded(LimitKind),
-    /// A memory allocation failed — distinct from a configured resource limit.
-    OutOfMemory,
+    /// policy refused it. Understood and *declined*; often maps to HTTP 422.
+    /// See [`PolicyKind`].
+    Policy(PolicyKind),
+    /// The operation was stopped via its [`Stop`](enough::Stop) token — cancelled
+    /// by the caller or past its deadline. Carries the
+    /// [`StopReason`](enough::StopReason) (`Cancelled` / `TimedOut`).
+    Lifecycle(StopReason),
     /// An underlying I/O or output-sink operation failed. Carries a
     /// [`CodecIoKind`] — a `std::io::ErrorKind` when the `std` feature is
     /// enabled, empty under `no_std` (the variant shape is stable across builds).
     Io(CodecIoKind),
-    /// Caller-supplied configuration or parameters were invalid — not the image's fault.
-    InvalidParameters,
+    /// An internal failure not attributable to the input or the request. See
+    /// [`InternalKind`].
+    Internal(InternalKind),
+}
+
+/// Which side of the encode/decode boundary a [`ErrorCategory::Policy`] rejection
+/// applies to — mirrors the crate's existing
+/// [`DecodePolicy`](crate::decode::DecodePolicy) /
+/// [`EncodePolicy`](crate::encode::EncodePolicy) split, so a codec constructing
+/// the error already knows which one at the call site.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum PolicyKind {
+    /// A [`DecodePolicy`](crate::decode::DecodePolicy) refused otherwise-decodable
+    /// input — e.g. rejecting progressive content in strict mode.
+    Decode,
+    /// An [`EncodePolicy`](crate::encode::EncodePolicy) refused an
+    /// otherwise-performable transform — e.g. forbidding alpha removal, or an ICC
+    /// downgrade.
+    Encode,
+}
+
+/// Which kind of [`ErrorCategory::Internal`] failure — a coarse split for
+/// telemetry/triage, not a replacement for the downcast-recoverable detail
+/// error (`CodecErrorExt::find_cause`, the `At` trace).
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum InternalKind {
+    /// A broken invariant or assertion inside this codec's own logic. Always a
+    /// code defect: never retryable, always alert-worthy, will recur on the same
+    /// input.
+    Bug,
+    /// An error surfaced from a sub-component or foreign library that this codec
+    /// hasn't (or structurally can't) classify into [`ErrorCategory::Image`] /
+    /// [`ErrorCategory::Request`] / [`ErrorCategory::Resource`]. An honest
+    /// "unclassified", not a permanent home — a call site that only ever produces
+    /// `Dependency` is a taxonomy gap worth closing, not a fact about the world.
+    Dependency,
+}
+
+/// Image-bytes-origin failure kind — the payload of [`ErrorCategory::Image`].
+///
+/// Everything here is "the bytes are the problem": a generic consumer treats the
+/// whole [`Image`](ErrorCategory::Image) arm as a client-supplied-data fault (a
+/// truncated/incomplete request is `UnexpectedEof`; the rest are 4xx-class
+/// unprocessable content). This is exactly the set a truncation-conformance check
+/// tolerates.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ImageError {
+    /// The encoded bytes are invalid or corrupt — bad bitstream content.
+    Malformed,
+    /// Input ended before a complete image could be read (truncated / insufficient).
+    UnexpectedEof,
+    /// The bytes are a *well-formed* image this codec doesn't handle — an
+    /// unrecognized format/profile, or an encoded feature it hasn't implemented.
+    /// See [`UnsupportedImageKind`].
+    Unsupported(UnsupportedImageKind),
+}
+
+/// Which image-bytes-origin "unsupported" — the payload of [`ImageError::Unsupported`].
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum UnsupportedImageKind {
+    /// The format / container / codec / profile itself is not handled
+    /// (e.g. "not a PNG", an unknown variant, an unsupported HEVC profile).
+    Type,
+    /// The format *is* handled, but the bitstream uses a feature this codec
+    /// hasn't implemented (e.g. arithmetic-coded JPEG, an unsupported chunk).
+    Feature,
+}
+
+/// Caller-request-origin failure kind — the payload of [`ErrorCategory::Request`].
+///
+/// Everything here is "the *request* is the problem, not the bytes": the caller
+/// can change config, buffer, call sequence, or the operation/format it asked for.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum RequestError {
+    /// The request is malformed at the API level — bad config, pixel buffer, or
+    /// call sequence. See [`InvalidKind`].
+    Invalid(InvalidKind),
+    /// The request is *well-formed* but asks for an API operation or pixel format
+    /// this codec doesn't support — the [`UnsupportedOperation`] axis (animation,
+    /// row-level, multi-image, pixel-format negotiation, …). Carries which one.
+    Unsupported(UnsupportedOperation),
+    /// The codec needs a colour-management transform / ICC profile it will not
+    /// perform itself (CMS is the caller's job) — e.g. an encode target whose ICC
+    /// profile cannot be synthesized. The caller must supply the transform.
+    CmsRequired,
+}
+
+/// Which caller-request "invalid" — the payload of [`RequestError::Invalid`].
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum InvalidKind {
+    /// Caller-supplied configuration or parameters were invalid — not the image's
+    /// fault (knobs, quality, scan script, …).
+    Parameters,
     /// A caller-supplied pixel buffer has an invalid layout — wrong size, stride,
     /// alignment, or [`PixelDescriptor`](zenpixels::PixelDescriptor) for the
-    /// operation. Distinct from [`InvalidParameters`](Self::InvalidParameters)
-    /// (config/knobs): this is specifically the pixel-data buffer's geometry.
-    InvalidBuffer,
+    /// operation. Specifically the pixel-data buffer's geometry.
+    Buffer,
     /// The operation was invoked in an invalid state or out of sequence — e.g.
-    /// pushing rows after `finish()`, a streaming ring-buffer overflow, or using
-    /// a cached reference before it was set. An API-protocol violation by the
-    /// caller, not bad image data.
-    InvalidState,
-    /// An internal failure: a bug, a broken invariant, or a sub-component error
-    /// not attributable to the input.
-    Internal,
+    /// pushing rows after `finish()`, a streaming ring-buffer overflow, or using a
+    /// cached reference before it was set. An API-protocol violation by the caller.
+    State,
+}
+
+/// Resource-origin failure kind — the payload of [`ErrorCategory::Resource`].
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ResourceError {
+    /// A [`ResourceLimits`](crate::ResourceLimits) cap was (or would be) exceeded.
+    /// Carries which [`LimitKind`].
+    Limits(LimitKind),
+    /// A memory allocation failed — distinct from a configured cap (retry with a
+    /// smaller input / more RAM may help; a cap is a policy the caller set).
+    OutOfMemory,
+}
+
+// Ergonomic lifts so a codec's `category()` map reads `ImageError::Malformed.into()`
+// / `RequestError::Invalid(InvalidKind::Buffer).into()` instead of spelling the
+// outer wrapper at every arm.
+impl From<ImageError> for ErrorCategory {
+    #[inline]
+    fn from(e: ImageError) -> Self {
+        Self::Image(e)
+    }
+}
+impl From<RequestError> for ErrorCategory {
+    #[inline]
+    fn from(e: RequestError) -> Self {
+        Self::Request(e)
+    }
+}
+impl From<ResourceError> for ErrorCategory {
+    #[inline]
+    fn from(e: ResourceError) -> Self {
+        Self::Resource(e)
+    }
+}
+impl From<StopReason> for ErrorCategory {
+    #[inline]
+    fn from(r: StopReason) -> Self {
+        Self::Lifecycle(r)
+    }
+}
+impl From<UnsupportedImageKind> for ErrorCategory {
+    #[inline]
+    fn from(k: UnsupportedImageKind) -> Self {
+        Self::Image(ImageError::Unsupported(k))
+    }
+}
+impl From<InvalidKind> for ErrorCategory {
+    #[inline]
+    fn from(k: InvalidKind) -> Self {
+        Self::Request(RequestError::Invalid(k))
+    }
+}
+impl From<PolicyKind> for ErrorCategory {
+    #[inline]
+    fn from(k: PolicyKind) -> Self {
+        Self::Policy(k)
+    }
+}
+impl From<InternalKind> for ErrorCategory {
+    #[inline]
+    fn from(k: InternalKind) -> Self {
+        Self::Internal(k)
+    }
+}
+impl From<LimitKind> for ErrorCategory {
+    #[inline]
+    fn from(k: LimitKind) -> Self {
+        Self::Resource(ResourceError::Limits(k))
+    }
 }
 
 impl core::fmt::Display for ErrorCategory {
@@ -85,23 +233,67 @@ impl core::fmt::Display for ErrorCategory {
     /// detail error to render.
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::MalformedImage => f.write_str("malformed image"),
-            Self::UnexpectedEof => f.write_str("unexpected end of input"),
-            Self::UnsupportedImageType => f.write_str("unsupported image type"),
-            Self::UnsupportedImageFeature => f.write_str("unsupported image feature"),
-            Self::UnsupportedPixelFormat => f.write_str("no acceptable pixel format"),
-            Self::UnsupportedOperation => f.write_str("unsupported operation"),
-            Self::CmsRequired => f.write_str("colour-management transform required"),
-            Self::PolicyRejected => f.write_str("rejected by policy"),
-            Self::Cancelled => f.write_str("cancelled"),
-            Self::TimedOut => f.write_str("timed out"),
-            Self::LimitsExceeded(kind) => write!(f, "resource limit exceeded ({kind:?})"),
-            Self::OutOfMemory => f.write_str("out of memory"),
+            Self::Image(e) => write!(f, "{e}"),
+            Self::Request(e) => write!(f, "{e}"),
+            Self::Resource(e) => write!(f, "{e}"),
+            Self::Policy(k) => write!(f, "{k}"),
+            Self::Lifecycle(e) => write!(f, "{e}"),
             Self::Io(_) => f.write_str("I/O error"),
-            Self::InvalidParameters => f.write_str("invalid parameters"),
-            Self::InvalidBuffer => f.write_str("invalid pixel buffer"),
-            Self::InvalidState => f.write_str("invalid state"),
-            Self::Internal => f.write_str("internal error"),
+            Self::Internal(k) => write!(f, "{k}"),
+        }
+    }
+}
+
+impl core::fmt::Display for PolicyKind {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Decode => f.write_str("rejected by decode policy"),
+            Self::Encode => f.write_str("rejected by encode policy"),
+        }
+    }
+}
+
+impl core::fmt::Display for InternalKind {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Bug => f.write_str("internal error (bug)"),
+            Self::Dependency => f.write_str("internal error (unclassified dependency failure)"),
+        }
+    }
+}
+
+impl core::fmt::Display for ImageError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Malformed => f.write_str("malformed image"),
+            Self::UnexpectedEof => f.write_str("unexpected end of input"),
+            Self::Unsupported(UnsupportedImageKind::Type) => f.write_str("unsupported image type"),
+            Self::Unsupported(UnsupportedImageKind::Feature) => {
+                f.write_str("unsupported image feature")
+            }
+        }
+    }
+}
+
+impl core::fmt::Display for RequestError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Invalid(InvalidKind::Parameters) => f.write_str("invalid parameters"),
+            Self::Invalid(InvalidKind::Buffer) => f.write_str("invalid pixel buffer"),
+            Self::Invalid(InvalidKind::State) => f.write_str("invalid state"),
+            // `UnsupportedOperation`'s own Display already reads "unsupported
+            // operation: <op>" (and "no acceptable pixel format" for PixelFormat).
+            Self::Unsupported(op) => write!(f, "{op}"),
+            Self::CmsRequired => f.write_str("colour-management transform required"),
+        }
+    }
+}
+
+impl core::fmt::Display for ResourceError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Limits(kind) => write!(f, "resource limit exceeded ({kind:?})"),
+            Self::OutOfMemory => f.write_str("out of memory"),
         }
     }
 }
@@ -188,7 +380,7 @@ impl From<&std::io::Error> for CodecIoKind {
 /// # Example
 ///
 /// ```rust
-/// use zencodec::{CategorizedError, ErrorCategory, UnsupportedOperation};
+/// use zencodec::{CategorizedError, ErrorCategory, ImageError, UnsupportedOperation};
 ///
 /// #[derive(Debug)]
 /// enum MyError {
@@ -201,13 +393,13 @@ impl From<&std::io::Error> for CodecIoKind {
 ///     fn codec_name(&self) -> Option<&'static str> { Some("mycodec") } // declared once
 ///     fn category(&self) -> ErrorCategory {
 ///         match self {
-///             MyError::Corrupt => ErrorCategory::MalformedImage,
-///             MyError::Truncated => ErrorCategory::UnexpectedEof,
+///             MyError::Corrupt => ErrorCategory::Image(ImageError::Malformed),
+///             MyError::Truncated => ErrorCategory::Image(ImageError::UnexpectedEof),
 ///             MyError::Unsupported(op) => op.category(), // delegate to the zencodec arm
 ///         }
 ///     }
 /// }
-/// assert_eq!(MyError::Corrupt.category(), ErrorCategory::MalformedImage);
+/// assert_eq!(MyError::Corrupt.category(), ErrorCategory::Image(ImageError::Malformed));
 /// assert_eq!(MyError::Corrupt.codec_name(), Some("mycodec"));
 /// ```
 pub trait CategorizedError: core::any::Any {
@@ -250,11 +442,9 @@ impl CategorizedError for StopReason {
     }
     #[inline]
     fn category(&self) -> ErrorCategory {
-        match self {
-            StopReason::TimedOut => ErrorCategory::TimedOut,
-            // `Cancelled`, plus any future `#[non_exhaustive]` reason, is a cancellation.
-            _ => ErrorCategory::Cancelled,
-        }
+        // The stop reason IS the payload — no lossy collapse; a future
+        // `#[non_exhaustive]` reason flows through unchanged.
+        ErrorCategory::Lifecycle(*self)
     }
 }
 
@@ -265,12 +455,10 @@ impl CategorizedError for UnsupportedOperation {
     }
     #[inline]
     fn category(&self) -> ErrorCategory {
-        match self {
-            // The "no acceptable pixel format" arm is a negotiation failure, not
-            // an API-operation gap.
-            UnsupportedOperation::PixelFormat => ErrorCategory::UnsupportedPixelFormat,
-            _ => ErrorCategory::UnsupportedOperation,
-        }
+        // The whole operation axis (including `PixelFormat`) is a caller-request
+        // fault. Carry *which* op through as the payload instead of flattening it
+        // to a single coarse category — the audit found all delegators lost it.
+        ErrorCategory::Request(RequestError::Unsupported(*self))
     }
 }
 
@@ -281,7 +469,7 @@ impl CategorizedError for LimitExceeded {
     }
     #[inline]
     fn category(&self) -> ErrorCategory {
-        ErrorCategory::LimitsExceeded(self.kind())
+        ErrorCategory::Resource(ResourceError::Limits(self.kind()))
     }
 }
 
@@ -318,7 +506,10 @@ impl CategorizedError for LimitExceeded {
 /// # Example
 ///
 /// ```rust
-/// use zencodec::{At, CategorizedError, CodecError, ErrorAtExt, ErrorCategory, UnsupportedOperation};
+/// use zencodec::{
+///     At, CategorizedError, CodecError, ErrorAtExt, ErrorCategory, ImageError, RequestError,
+///     UnsupportedOperation,
+/// };
 ///
 /// // A codec's native error declares its name once and maps its variants:
 /// #[derive(Debug)]
@@ -336,17 +527,17 @@ impl CategorizedError for LimitExceeded {
 /// // reads the category AND the codec name from the type — no codec arg:
 /// let e: At<CodecError> =
 ///     CodecError::of(JpegError(UnsupportedOperation::AnimationEncode).start_at());
-/// assert_eq!(e.category(), ErrorCategory::UnsupportedOperation); // via At's CategorizedError
+/// assert_eq!(e.category(), ErrorCategory::Request(RequestError::Unsupported(UnsupportedOperation::AnimationEncode))); // via At's CategorizedError
 /// assert_eq!(e.error().codec(), Some("zenjpeg"));
 ///
 /// // `new` is the fundamental form — codec name passed, no detail:
-/// let bare = CodecError::new(Some("zenjpeg"), ErrorCategory::MalformedImage);
+/// let bare = CodecError::new(Some("zenjpeg"), ErrorCategory::Image(ImageError::Malformed));
 /// assert!(bare.detail().is_none());
 ///
 /// // Everything survives erasure to a trait object — recover by concrete downcast:
 /// let boxed: Box<dyn core::error::Error + Send + Sync> = Box::new(e);
 /// let recovered = boxed.downcast_ref::<At<CodecError>>().unwrap();
-/// assert_eq!(recovered.category(), ErrorCategory::UnsupportedOperation);
+/// assert_eq!(recovered.category(), ErrorCategory::Request(RequestError::Unsupported(UnsupportedOperation::AnimationEncode)));
 /// assert_eq!(recovered.error().codec(), Some("zenjpeg"));
 /// ```
 pub struct CodecError(Box<Repr>);
@@ -543,10 +734,10 @@ impl core::error::Error for CodecError {
 /// "where did it fail". The unit is bytes from the start of the encoded input.
 ///
 /// ```rust
-/// use zencodec::{At, CodecError, ErrorAtExt, ErrorCategory, StreamOffset};
+/// use zencodec::{At, CodecError, ErrorAtExt, ErrorCategory, ImageError, StreamOffset};
 ///
 /// // A codec attaches the offset where parsing failed to its error's trace:
-/// let err: At<CodecError> = CodecError::new(Some("zenjpeg"), ErrorCategory::MalformedImage)
+/// let err: At<CodecError> = CodecError::new(Some("zenjpeg"), ErrorCategory::Image(ImageError::Malformed))
 ///     .start_at()
 ///     .at_data(|| StreamOffset(42));
 ///
@@ -808,10 +999,14 @@ mod tests {
                 Self::Limit(e) => e.category(),
                 Self::Unsupported(e) => e.category(),
                 Self::Cancelled(r) => r.category(),
-                Self::Malformed(_) => ErrorCategory::MalformedImage,
-                Self::RejectedByPolicy => ErrorCategory::PolicyRejected,
-                Self::BadBuffer => ErrorCategory::InvalidBuffer,
-                Self::WrongState => ErrorCategory::InvalidState,
+                Self::Malformed(_) => ErrorCategory::Image(ImageError::Malformed),
+                Self::RejectedByPolicy => ErrorCategory::Policy(PolicyKind::Decode),
+                Self::BadBuffer => {
+                    ErrorCategory::Request(RequestError::Invalid(InvalidKind::Buffer))
+                }
+                Self::WrongState => {
+                    ErrorCategory::Request(RequestError::Invalid(InvalidKind::State))
+                }
             }
         }
     }
@@ -886,54 +1081,64 @@ mod tests {
     fn category_maps_each_codec_variant() {
         assert_eq!(
             TestCodecError::Malformed("x".into()).category(),
-            ErrorCategory::MalformedImage
+            ErrorCategory::Image(ImageError::Malformed)
         );
         assert_eq!(
             TestCodecError::RejectedByPolicy.category(),
-            ErrorCategory::PolicyRejected
+            ErrorCategory::Policy(PolicyKind::Decode)
         );
         assert_eq!(
             TestCodecError::BadBuffer.category(),
-            ErrorCategory::InvalidBuffer
+            ErrorCategory::Request(RequestError::Invalid(InvalidKind::Buffer))
         );
         assert_eq!(
             TestCodecError::WrongState.category(),
-            ErrorCategory::InvalidState
+            ErrorCategory::Request(RequestError::Invalid(InvalidKind::State))
         );
         assert_eq!(
             TestCodecError::Unsupported(UnsupportedOperation::AnimationEncode).category(),
-            ErrorCategory::UnsupportedOperation
+            ErrorCategory::Request(RequestError::Unsupported(
+                UnsupportedOperation::AnimationEncode
+            ))
         );
         assert_eq!(
             TestCodecError::Cancelled(StopReason::Cancelled).category(),
-            ErrorCategory::Cancelled
+            ErrorCategory::Lifecycle(StopReason::Cancelled)
         );
         assert_eq!(
             TestCodecError::Cancelled(StopReason::TimedOut).category(),
-            ErrorCategory::TimedOut
+            ErrorCategory::Lifecycle(StopReason::TimedOut)
         );
         assert_eq!(
             TestCodecError::Limit(LimitExceeded::Pixels { actual: 9, max: 4 }).category(),
-            ErrorCategory::LimitsExceeded(LimitKind::Pixels)
+            ErrorCategory::Resource(ResourceError::Limits(LimitKind::Pixels))
         );
     }
 
     #[test]
     fn zencodec_cause_types_categorize() {
-        assert_eq!(StopReason::Cancelled.category(), ErrorCategory::Cancelled);
-        assert_eq!(StopReason::TimedOut.category(), ErrorCategory::TimedOut);
+        assert_eq!(
+            StopReason::Cancelled.category(),
+            ErrorCategory::Lifecycle(StopReason::Cancelled)
+        );
+        assert_eq!(
+            StopReason::TimedOut.category(),
+            ErrorCategory::Lifecycle(StopReason::TimedOut)
+        );
         // The operation axis splits: a plain operation vs the pixel-format arm.
         assert_eq!(
             UnsupportedOperation::AnimationDecode.category(),
-            ErrorCategory::UnsupportedOperation
+            ErrorCategory::Request(RequestError::Unsupported(
+                UnsupportedOperation::AnimationDecode
+            ))
         );
         assert_eq!(
             UnsupportedOperation::PixelFormat.category(),
-            ErrorCategory::UnsupportedPixelFormat
+            ErrorCategory::Request(RequestError::Unsupported(UnsupportedOperation::PixelFormat))
         );
         assert_eq!(
             LimitExceeded::Memory { actual: 2, max: 1 }.category(),
-            ErrorCategory::LimitsExceeded(LimitKind::Memory)
+            ErrorCategory::Resource(ResourceError::Limits(LimitKind::Memory))
         );
     }
 
@@ -942,7 +1147,10 @@ mod tests {
         // A located error (the form heic/zenbitmaps return) keeps its category,
         // and the inner error is still reachable for its detail.
         let located = At::wrap(TestCodecError::Cancelled(StopReason::TimedOut));
-        assert_eq!(located.category(), ErrorCategory::TimedOut);
+        assert_eq!(
+            located.category(),
+            ErrorCategory::Lifecycle(StopReason::TimedOut)
+        );
         assert!(matches!(
             located.error(),
             TestCodecError::Cancelled(StopReason::TimedOut)
@@ -955,7 +1163,7 @@ mod tests {
     fn codec_error_from_native_and_of_capture_category_and_codec() {
         // `from_native` reads both the category and the codec name from the type.
         let e = CodecError::from_native(TestCodecError::Malformed("bad".into()));
-        assert_eq!(e.category(), ErrorCategory::MalformedImage);
+        assert_eq!(e.category(), ErrorCategory::Image(ImageError::Malformed));
         assert_eq!(e.codec(), Some("test-codec")); // TestCodecError::codec_name
         assert!(e.detail().is_some());
         // Display is "{codec}: {detail message}".
@@ -963,7 +1171,10 @@ mod tests {
         // `of` is the located form: takes At<E>, keeps the trace on the outside.
         let located: At<CodecError> =
             CodecError::of(At::wrap(TestCodecError::Malformed("bad".into())));
-        assert_eq!(located.category(), ErrorCategory::MalformedImage);
+        assert_eq!(
+            located.category(),
+            ErrorCategory::Image(ImageError::Malformed)
+        );
         assert_eq!(located.error().codec(), Some("test-codec"));
         // from_parts takes an explicit category + codec name (no typed detail):
         let e2 = CodecError::from_parts(
@@ -978,8 +1189,8 @@ mod tests {
     #[test]
     fn codec_error_new_is_detail_free() {
         // The fundamental form: a codec with no error enum of its own.
-        let e = CodecError::new(Some("zenpng"), ErrorCategory::MalformedImage);
-        assert_eq!(e.category(), ErrorCategory::MalformedImage);
+        let e = CodecError::new(Some("zenpng"), ErrorCategory::Image(ImageError::Malformed));
+        assert_eq!(e.category(), ErrorCategory::Image(ImageError::Malformed));
         assert_eq!(e.codec(), Some("zenpng"));
         assert!(e.detail().is_none());
         // With no detail, Display falls back to the category's phrase.
@@ -992,7 +1203,10 @@ mod tests {
         // category AND the originating codec name survive erasure.
         let located = CodecError::of(At::wrap(TestCodecError::Cancelled(StopReason::Cancelled)));
         let boxed: Box<dyn core::error::Error + Send + Sync> = Box::new(located);
-        assert_eq!(boxed.error_category(), Some(ErrorCategory::Cancelled));
+        assert_eq!(
+            boxed.error_category(),
+            Some(ErrorCategory::Lifecycle(StopReason::Cancelled))
+        );
         assert_eq!(
             boxed.codec_error().and_then(CodecError::codec),
             Some("test-codec")
@@ -1000,7 +1214,12 @@ mod tests {
         // A bare CodecError (no At) recovers too.
         let bare: Box<dyn core::error::Error + Send + Sync> =
             Box::new(CodecError::from_native(TestCodecError::WrongState));
-        assert_eq!(bare.error_category(), Some(ErrorCategory::InvalidState));
+        assert_eq!(
+            bare.error_category(),
+            Some(ErrorCategory::Request(RequestError::Invalid(
+                InvalidKind::State
+            )))
+        );
         assert_eq!(
             bare.codec_error().and_then(CodecError::codec),
             Some("test-codec")
@@ -1033,7 +1252,9 @@ mod tests {
         ))));
         assert_eq!(
             wrapped.error_category(),
-            Some(ErrorCategory::LimitsExceeded(LimitKind::Pixels))
+            Some(ErrorCategory::Resource(ResourceError::Limits(
+                LimitKind::Pixels
+            )))
         );
         assert_eq!(
             wrapped.codec_error().and_then(CodecError::codec),
@@ -1050,7 +1271,9 @@ mod tests {
         assert_eq!(located.limit_exceeded(), Some(&inner));
         assert_eq!(
             located.error_category(),
-            Some(ErrorCategory::LimitsExceeded(LimitKind::Memory))
+            Some(ErrorCategory::Resource(ResourceError::Limits(
+                LimitKind::Memory
+            )))
         );
     }
 
@@ -1071,7 +1294,7 @@ mod tests {
         // recovered generically (no codec-specific type named) after erasure.
         let err = At::wrap(CodecError::new(
             Some("zenjpeg"),
-            ErrorCategory::MalformedImage,
+            ErrorCategory::Image(ImageError::Malformed),
         ))
         .at_data(|| StreamOffset(1234));
         let boxed: Box<dyn core::error::Error + Send + Sync> = Box::new(err);
@@ -1083,7 +1306,10 @@ mod tests {
             .find_map(|c| c.downcast_ref::<StreamOffset>().copied());
         assert_eq!(offset, Some(StreamOffset(1234)));
         // The category recovers alongside the locus.
-        assert_eq!(boxed.error_category(), Some(ErrorCategory::MalformedImage));
+        assert_eq!(
+            boxed.error_category(),
+            Some(ErrorCategory::Image(ImageError::Malformed))
+        );
     }
 
     #[test]
@@ -1120,13 +1346,13 @@ mod tests {
         // Recovery is downcast-based, but probes a single `Box` layer in either
         // position too, so a consumer that boxed the (already one-word) envelope is
         // still classifiable.
-        let mk = || CodecError::new(Some("zenjpeg"), ErrorCategory::MalformedImage);
+        let mk = || CodecError::new(Some("zenjpeg"), ErrorCategory::Image(ImageError::Malformed));
 
         // Canonical `At<CodecError>`.
         let canonical: Box<dyn core::error::Error + Send + Sync> = Box::new(At::wrap(mk()));
         assert_eq!(
             canonical.error_category(),
-            Some(ErrorCategory::MalformedImage)
+            Some(ErrorCategory::Image(ImageError::Malformed))
         );
         assert_eq!(
             canonical.codec_error().and_then(CodecError::codec),
@@ -1138,7 +1364,7 @@ mod tests {
             Box::new(Box::new(At::wrap(mk())) as Box<At<CodecError>>);
         assert_eq!(
             boxed_at.error_category(),
-            Some(ErrorCategory::MalformedImage)
+            Some(ErrorCategory::Image(ImageError::Malformed))
         );
         assert_eq!(
             boxed_at.codec_error().and_then(CodecError::codec),
@@ -1150,7 +1376,7 @@ mod tests {
             Box::new(At::wrap(Box::new(mk()) as Box<CodecError>));
         assert_eq!(
             at_boxed.error_category(),
-            Some(ErrorCategory::MalformedImage)
+            Some(ErrorCategory::Image(ImageError::Malformed))
         );
 
         // `Box<CodecError>` (no `At`).
@@ -1158,7 +1384,7 @@ mod tests {
             Box::new(Box::new(mk()) as Box<CodecError>);
         assert_eq!(
             bare_boxed.error_category(),
-            Some(ErrorCategory::MalformedImage)
+            Some(ErrorCategory::Image(ImageError::Malformed))
         );
 
         // The fallback is one layer deep — a pathological double box is not covered.
@@ -1187,7 +1413,10 @@ mod tests {
         use core::any::Any;
         let err = TestCodecError::WrongState;
         let dynamic: &dyn CategorizedError = &err;
-        assert_eq!(dynamic.category(), ErrorCategory::InvalidState);
+        assert_eq!(
+            dynamic.category(),
+            ErrorCategory::Request(RequestError::Invalid(InvalidKind::State))
+        );
         let any: &dyn Any = dynamic; // trait upcasting (Rust 1.86+)
         assert!(any.downcast_ref::<TestCodecError>().is_some());
     }
@@ -1197,7 +1426,7 @@ mod tests {
         // A foreign error wrapped with no codec name, then stamped via the builder.
         let e = CodecError::from_parts(
             None,
-            ErrorCategory::Internal,
+            ErrorCategory::Internal(InternalKind::Bug),
             Box::new(TestCodecError::Malformed("x".into())),
         );
         assert_eq!(e.codec(), None);

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,7 +44,7 @@ pub enum ErrorCategory {
     /// The operation was stopped via its [`Stop`](enough::Stop) token — cancelled
     /// by the caller or past its deadline. Carries the
     /// [`StopReason`](enough::StopReason) (`Cancelled` / `TimedOut`).
-    Lifecycle(StopReason),
+    Stopped(StopReason),
     /// An underlying I/O or output-sink operation failed. Carries a
     /// [`CodecIoKind`] — a `std::io::ErrorKind` when the `std` feature is
     /// enabled, empty under `no_std` (the variant shape is stable across builds).
@@ -194,7 +194,7 @@ impl From<ResourceError> for ErrorCategory {
 impl From<StopReason> for ErrorCategory {
     #[inline]
     fn from(r: StopReason) -> Self {
-        Self::Lifecycle(r)
+        Self::Stopped(r)
     }
 }
 impl From<UnsupportedImageKind> for ErrorCategory {
@@ -237,7 +237,7 @@ impl core::fmt::Display for ErrorCategory {
             Self::Request(e) => write!(f, "{e}"),
             Self::Resource(e) => write!(f, "{e}"),
             Self::Policy(k) => write!(f, "{k}"),
-            Self::Lifecycle(e) => write!(f, "{e}"),
+            Self::Stopped(e) => write!(f, "{e}"),
             Self::Io(_) => f.write_str("I/O error"),
             Self::Internal(k) => write!(f, "{k}"),
         }
@@ -444,7 +444,7 @@ impl CategorizedError for StopReason {
     fn category(&self) -> ErrorCategory {
         // The stop reason IS the payload — no lossy collapse; a future
         // `#[non_exhaustive]` reason flows through unchanged.
-        ErrorCategory::Lifecycle(*self)
+        ErrorCategory::Stopped(*self)
     }
 }
 
@@ -1103,11 +1103,11 @@ mod tests {
         );
         assert_eq!(
             TestCodecError::Cancelled(StopReason::Cancelled).category(),
-            ErrorCategory::Lifecycle(StopReason::Cancelled)
+            ErrorCategory::Stopped(StopReason::Cancelled)
         );
         assert_eq!(
             TestCodecError::Cancelled(StopReason::TimedOut).category(),
-            ErrorCategory::Lifecycle(StopReason::TimedOut)
+            ErrorCategory::Stopped(StopReason::TimedOut)
         );
         assert_eq!(
             TestCodecError::Limit(LimitExceeded::Pixels { actual: 9, max: 4 }).category(),
@@ -1119,11 +1119,11 @@ mod tests {
     fn zencodec_cause_types_categorize() {
         assert_eq!(
             StopReason::Cancelled.category(),
-            ErrorCategory::Lifecycle(StopReason::Cancelled)
+            ErrorCategory::Stopped(StopReason::Cancelled)
         );
         assert_eq!(
             StopReason::TimedOut.category(),
-            ErrorCategory::Lifecycle(StopReason::TimedOut)
+            ErrorCategory::Stopped(StopReason::TimedOut)
         );
         // The operation axis splits: a plain operation vs the pixel-format arm.
         assert_eq!(
@@ -1149,7 +1149,7 @@ mod tests {
         let located = At::wrap(TestCodecError::Cancelled(StopReason::TimedOut));
         assert_eq!(
             located.category(),
-            ErrorCategory::Lifecycle(StopReason::TimedOut)
+            ErrorCategory::Stopped(StopReason::TimedOut)
         );
         assert!(matches!(
             located.error(),
@@ -1205,7 +1205,7 @@ mod tests {
         let boxed: Box<dyn core::error::Error + Send + Sync> = Box::new(located);
         assert_eq!(
             boxed.error_category(),
-            Some(ErrorCategory::Lifecycle(StopReason::Cancelled))
+            Some(ErrorCategory::Stopped(StopReason::Cancelled))
         );
         assert_eq!(
             boxed.codec_error().and_then(CodecError::codec),

--- a/src/format/builtins.rs
+++ b/src/format/builtins.rs
@@ -140,7 +140,7 @@ fn detect_jxl(data: &[u8]) -> bool {
     // Container: 00 00 00 0C 4A 58 4C 20 0D 0A 87 0A
     data.len() >= 12
         && data[..4] == [0x00, 0x00, 0x00, 0x0C]
-        && data[4..8] == [b'J', b'X', b'L', b' ']
+        && data[4..8] == *b"JXL "
         && data[8..12] == [0x0D, 0x0A, 0x87, 0x0A]
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,8 +108,9 @@ pub use zenpixels::ColorAuthority;
 pub use capabilities::UnsupportedOperation;
 pub use detect::SourceEncodingDetails;
 pub use error::{
-    CategorizedError, CodecError, CodecErrorExt, CodecIoKind, ErrorCategory, StreamOffset,
-    find_cause,
+    CategorizedError, CodecError, CodecErrorExt, CodecIoKind, ErrorCategory, ImageError,
+    InternalKind, InvalidKind, PolicyKind, RequestError, ResourceError, StreamOffset,
+    UnsupportedImageKind, find_cause,
 };
 pub use traits::Unsupported;
 

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -710,8 +710,9 @@ pub enum LimitExceeded {
 
 /// Which resource cap a [`LimitExceeded`] refers to, without the actual/max
 /// values. Carried by
-/// [`ErrorCategory::LimitsExceeded`](crate::ErrorCategory::LimitsExceeded)
-/// for routing; obtain it from [`LimitExceeded::kind`].
+/// [`ResourceError::Limits`](crate::ResourceError::Limits) (the payload of
+/// [`ErrorCategory::Resource`](crate::ErrorCategory::Resource)) for routing;
+/// obtain it from [`LimitExceeded::kind`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum LimitKind {
@@ -733,6 +734,18 @@ pub enum LimitKind {
     Duration,
     /// [`LimitExceeded::TotalPixels`].
     TotalPixels,
+    /// A structural per-image cap on the number of coded passes / scans was
+    /// exceeded — e.g. a progressive-JPEG scan-count ceiling. An anti-DoS
+    /// bound on decode work, not a pixel/byte size. No [`LimitExceeded`]
+    /// variant carries actual/max for this; codecs route it directly via
+    /// [`ErrorCategory::Resource`](crate::ErrorCategory::Resource).
+    Scans,
+    /// A decompression-ratio ("compression bomb") ceiling was exceeded — the
+    /// declared/expanding output is disproportionate to the input size. A
+    /// security-relevant anti-DoS bound distinct from an absolute
+    /// [`Memory`](LimitKind::Memory) cap. Codecs route it directly via
+    /// [`ErrorCategory::Resource`](crate::ErrorCategory::Resource).
+    DecompressionRatio,
 }
 
 impl LimitExceeded {

--- a/zencodec-testkit/src/lib.rs
+++ b/zencodec-testkit/src/lib.rs
@@ -1282,7 +1282,7 @@ where
 /// [`Resource`](ErrorCategory::Resource) (OOM from an unvalidated length in truncated
 /// data, or a limit), [`Io`](ErrorCategory::Io) (there is no I/O on an in-memory slice),
 /// the caller-fault [`Request`](ErrorCategory::Request) set, the operation
-/// [`Lifecycle`](ErrorCategory::Lifecycle) set, and [`Policy`](ErrorCategory::Policy).
+/// [`Stopped`](ErrorCategory::Stopped) set, and [`Policy`](ErrorCategory::Policy).
 pub fn is_incomplete_input_category(cat: ErrorCategory) -> bool {
     // Default-DENY: `ErrorCategory` is `#[non_exhaustive]`, so any *future* variant
     // falls through to `false` and is conservatively flagged for review rather than
@@ -1540,7 +1540,7 @@ mod tests {
         // Classify it the way a generic consumer would, with no knowledge of RefError:
         assert_eq!(
             err.category(),
-            ErrorCategory::Lifecycle(zencodec::enough::StopReason::Cancelled)
+            ErrorCategory::Stopped(zencodec::enough::StopReason::Cancelled)
         );
         // ...and it must NOT be mistaken for a limit or an unsupported operation.
         assert!(err.limit_exceeded().is_none());
@@ -1718,8 +1718,8 @@ mod tests {
             E::Request(RequestError::Invalid(InvalidKind::State)),
             E::Policy(PolicyKind::Decode),
             E::Policy(PolicyKind::Encode),
-            E::Lifecycle(StopReason::Cancelled),
-            E::Lifecycle(StopReason::TimedOut),
+            E::Stopped(StopReason::Cancelled),
+            E::Stopped(StopReason::TimedOut),
             E::Resource(ResourceError::Limits(LimitKind::Pixels)),
             E::Resource(ResourceError::OutOfMemory),
             E::Io(CodecIoKind::opaque()),

--- a/zencodec-testkit/src/lib.rs
+++ b/zencodec-testkit/src/lib.rs
@@ -1269,40 +1269,27 @@ where
 
 /// Whether `cat` is an acceptable category for a truncated / incomplete input.
 ///
-/// TRUE for the incomplete-input set — [`UnexpectedEof`](ErrorCategory::UnexpectedEof)
-/// (the ideal) plus [`MalformedImage`](ErrorCategory::MalformedImage),
-/// [`UnsupportedImageType`](ErrorCategory::UnsupportedImageType), and
-/// [`UnsupportedImageFeature`](ErrorCategory::UnsupportedImageFeature), since a
-/// truncated prefix can legitimately look malformed or unrecognizable (a codec that
-/// can't yet tell "cut short" from "corrupt" this early is still safe — all four
-/// read as *client-supplied incomplete data*, an HTTP 4xx).
+/// TRUE for the whole image-bytes-origin cluster — [`ErrorCategory::Image`] with any
+/// [`ImageError`](zencodec::ImageError): [`UnexpectedEof`](zencodec::ImageError::UnexpectedEof)
+/// (the ideal), [`Malformed`](zencodec::ImageError::Malformed), or
+/// [`Unsupported`](zencodec::ImageError::Unsupported). A truncated prefix legitimately
+/// reads as *client-supplied incomplete data* (an HTTP 4xx): this early it may look
+/// cut-short, corrupt, or unrecognizable, and a codec that can't yet tell those apart
+/// is still safe as long as it stays inside the `Image` arm.
 ///
-/// FALSE for every category that MISATTRIBUTES a client-side truncation:
-/// [`Internal`](ErrorCategory::Internal) (reads as a codec bug / 5xx),
-/// [`OutOfMemory`](ErrorCategory::OutOfMemory) (the codec allocated from an
-/// unvalidated length in truncated data),
-/// [`LimitsExceeded`](ErrorCategory::LimitsExceeded), [`Io`](ErrorCategory::Io)
-/// (there is no I/O on an in-memory slice), the caller-fault set
-/// ([`InvalidParameters`](ErrorCategory::InvalidParameters) /
-/// [`InvalidBuffer`](ErrorCategory::InvalidBuffer) /
-/// [`InvalidState`](ErrorCategory::InvalidState)),
-/// [`Cancelled`](ErrorCategory::Cancelled) / [`TimedOut`](ErrorCategory::TimedOut),
-/// and the not-applicable
-/// [`UnsupportedPixelFormat`](ErrorCategory::UnsupportedPixelFormat) /
-/// [`UnsupportedOperation`](ErrorCategory::UnsupportedOperation) /
-/// [`CmsRequired`](ErrorCategory::CmsRequired) /
-/// [`PolicyRejected`](ErrorCategory::PolicyRejected).
+/// FALSE for every other origin, each of which MISATTRIBUTES a client-side truncation:
+/// [`Internal`](ErrorCategory::Internal) (a codec bug / 5xx),
+/// [`Resource`](ErrorCategory::Resource) (OOM from an unvalidated length in truncated
+/// data, or a limit), [`Io`](ErrorCategory::Io) (there is no I/O on an in-memory slice),
+/// the caller-fault [`Request`](ErrorCategory::Request) set, the operation
+/// [`Lifecycle`](ErrorCategory::Lifecycle) set, and [`Policy`](ErrorCategory::Policy).
 pub fn is_incomplete_input_category(cat: ErrorCategory) -> bool {
     // Default-DENY: `ErrorCategory` is `#[non_exhaustive]`, so any *future* variant
     // falls through to `false` and is conservatively flagged for review rather than
-    // silently accepted as a valid truncation category.
-    matches!(
-        cat,
-        ErrorCategory::UnexpectedEof
-            | ErrorCategory::MalformedImage
-            | ErrorCategory::UnsupportedImageType
-            | ErrorCategory::UnsupportedImageFeature
-    )
+    // silently accepted as a valid truncation category. The image-bytes-origin arm
+    // (`Image(_)`) IS exactly the incomplete-input-tolerable set — a truncated prefix
+    // is always a client-supplied-data fault, never a codec bug or caller-request fault.
+    matches!(cat, ErrorCategory::Image(_))
 }
 
 /// Deterministic series of truncation lengths spanning a `len`-byte bitstream: the
@@ -1329,10 +1316,10 @@ fn truncation_lengths(len: usize) -> Vec<usize> {
 /// This enforces the one part of the [`ErrorCategory`] taxonomy that IS broadly
 /// distinguishable: whatever a codec's exact error, cutting a known-good image
 /// short must land in the *incomplete-input* set
-/// ([`is_incomplete_input_category`] — [`UnexpectedEof`](ErrorCategory::UnexpectedEof)
-/// is ideal, but [`MalformedImage`](ErrorCategory::MalformedImage) /
-/// `UnsupportedImageType` / `UnsupportedImageFeature` are tolerated because a
-/// truncated prefix can genuinely look malformed). It catches the real bug class
+/// ([`is_incomplete_input_category`] — [`UnexpectedEof`](zencodec::ImageError::UnexpectedEof)
+/// is ideal, but the rest of the image-bytes-origin [`Image`](ErrorCategory::Image) arm
+/// ([`Malformed`](zencodec::ImageError::Malformed) / [`Unsupported`](zencodec::ImageError::Unsupported))
+/// is tolerated because a truncated prefix can genuinely look malformed). It catches the real bug class
 /// where a codec reads a length field out of truncated data and OOMs, or funnels a
 /// truncation into [`Internal`](ErrorCategory::Internal) — a 5xx for a 4xx-class
 /// client error.
@@ -1551,7 +1538,10 @@ mod tests {
             .expect_err("a fired stop token must cancel the push");
 
         // Classify it the way a generic consumer would, with no knowledge of RefError:
-        assert_eq!(err.category(), ErrorCategory::Cancelled);
+        assert_eq!(
+            err.category(),
+            ErrorCategory::Lifecycle(zencodec::enough::StopReason::Cancelled)
+        );
         // ...and it must NOT be mistaken for a limit or an unsupported operation.
         assert!(err.limit_exceeded().is_none());
         assert!(err.unsupported_operation().is_none());
@@ -1577,7 +1567,10 @@ mod tests {
             .expect_err("malformed header must fail");
         // A consumer holding only `Box<dyn Error>` recovers the category — and
         // the originating codec name, so it can tell codecs apart generically.
-        assert_eq!(erased.error_category(), Some(ErrorCategory::MalformedImage));
+        assert_eq!(
+            erased.error_category(),
+            Some(ErrorCategory::Image(zencodec::ImageError::Malformed))
+        );
         assert_eq!(
             erased.codec_error().and_then(CodecError::codec),
             Some(crate::reference::MINIMAL_CODEC_NAME)
@@ -1610,13 +1603,19 @@ mod tests {
             .decoder(Cow::Borrowed(b"not a ZCR1 header"), &[])
             .expect_err("malformed header must fail");
         // Total category + codec name via the concrete envelope:
-        assert_eq!(err.error().category(), ErrorCategory::MalformedImage);
+        assert_eq!(
+            err.error().category(),
+            ErrorCategory::Image(zencodec::ImageError::Malformed)
+        );
         assert_eq!(
             err.error().codec(),
             Some(crate::reference::MINIMAL_CODEC_NAME)
         );
         // Same category via the generic Option recovery:
-        assert_eq!(err.error_category(), Some(ErrorCategory::MalformedImage));
+        assert_eq!(
+            err.error_category(),
+            Some(ErrorCategory::Image(zencodec::ImageError::Malformed))
+        );
         // The trace was started by the bridge's `.start_at()`.
         let dbg = format!("{err:?}");
         assert!(dbg.contains("at "), "expected a trace frame: {dbg}");
@@ -1680,21 +1679,26 @@ mod tests {
 
     // ---- EOF / truncation-series conformance ----
 
-    /// The allowed/denied policy of [`is_incomplete_input_category`] over ALL 17
-    /// current [`ErrorCategory`] variants: the four incomplete-input categories
-    /// pass; every other variant — including the misattribution traps `OutOfMemory`,
-    /// `Internal`, `LimitsExceeded`, and `Io` — is denied.
+    /// The allowed/denied policy of [`is_incomplete_input_category`] over the
+    /// origin-first [`ErrorCategory`] taxonomy: the entire image-bytes-origin
+    /// [`Image`](ErrorCategory::Image) arm passes; every other origin — including the
+    /// misattribution traps [`Resource`](ErrorCategory::Resource) (OOM / limits),
+    /// [`Internal`](ErrorCategory::Internal), and [`Io`](ErrorCategory::Io) — is denied.
     #[test]
     fn incomplete_input_category_policy() {
-        use zencodec::{CodecIoKind, ErrorCategory as E, LimitKind};
+        use zencodec::enough::StopReason;
+        use zencodec::{
+            CodecIoKind, ErrorCategory as E, ImageError, InternalKind, InvalidKind, LimitKind,
+            PolicyKind, RequestError, ResourceError, UnsupportedImageKind, UnsupportedOperation,
+        };
 
-        // The four allowed (UnexpectedEof ideal; the malformed/unrecognizable trio
-        // tolerated because a truncated prefix can look that way).
+        // The whole `Image(_)` arm is allowed (UnexpectedEof ideal; Malformed and both
+        // Unsupported kinds tolerated because a truncated prefix can look that way).
         for c in [
-            E::UnexpectedEof,
-            E::MalformedImage,
-            E::UnsupportedImageType,
-            E::UnsupportedImageFeature,
+            E::Image(ImageError::UnexpectedEof),
+            E::Image(ImageError::Malformed),
+            E::Image(ImageError::Unsupported(UnsupportedImageKind::Type)),
+            E::Image(ImageError::Unsupported(UnsupportedImageKind::Feature)),
         ] {
             assert!(
                 is_incomplete_input_category(c),
@@ -1702,21 +1706,25 @@ mod tests {
             );
         }
 
-        // Every other current variant is denied (13 → 4 + 13 = all 17 variants).
+        // Every non-`Image` origin is denied (representative payload per arm).
         for c in [
-            E::UnsupportedPixelFormat,
-            E::UnsupportedOperation,
-            E::CmsRequired,
-            E::PolicyRejected,
-            E::Cancelled,
-            E::TimedOut,
-            E::LimitsExceeded(LimitKind::Pixels),
-            E::OutOfMemory,
+            E::Request(RequestError::Unsupported(UnsupportedOperation::PixelFormat)),
+            E::Request(RequestError::Unsupported(
+                UnsupportedOperation::AnimationEncode,
+            )),
+            E::Request(RequestError::CmsRequired),
+            E::Request(RequestError::Invalid(InvalidKind::Parameters)),
+            E::Request(RequestError::Invalid(InvalidKind::Buffer)),
+            E::Request(RequestError::Invalid(InvalidKind::State)),
+            E::Policy(PolicyKind::Decode),
+            E::Policy(PolicyKind::Encode),
+            E::Lifecycle(StopReason::Cancelled),
+            E::Lifecycle(StopReason::TimedOut),
+            E::Resource(ResourceError::Limits(LimitKind::Pixels)),
+            E::Resource(ResourceError::OutOfMemory),
             E::Io(CodecIoKind::opaque()),
-            E::InvalidParameters,
-            E::InvalidBuffer,
-            E::InvalidState,
-            E::Internal,
+            E::Internal(InternalKind::Bug),
+            E::Internal(InternalKind::Dependency),
         ] {
             assert!(
                 !is_incomplete_input_category(c),
@@ -2045,7 +2053,7 @@ mod tests {
 
         let err = At::wrap(CodecError::new(
             Some("demo-codec"),
-            zencodec::ErrorCategory::MalformedImage,
+            zencodec::ErrorCategory::Image(zencodec::ImageError::Malformed),
         ))
         .at_crate(&CODEC_CRATE)
         .at()

--- a/zencodec-testkit/src/reference.rs
+++ b/zencodec-testkit/src/reference.rs
@@ -104,7 +104,7 @@ impl CategorizedError for RefError {
     fn category(&self) -> ErrorCategory {
         match self {
             Self::Unsupported(e) => e.category(),
-            Self::Invalid(_) => ErrorCategory::MalformedImage,
+            Self::Invalid(_) => ErrorCategory::Image(zencodec::ImageError::Malformed),
             Self::Cancelled(r) => r.category(),
             Self::Limit(e) => e.category(),
             Self::Sink(_) => ErrorCategory::Io(CodecIoKind::opaque()),


### PR DESCRIPTION
## Summary

Reshapes the still-**unreleased** `ErrorCategory` (from #99 / #103 — never published to crates.io, so this is not a break of any public API) from a flat 17-variant enum into an **origin-first, two-level** taxonomy:

```rust
enum ErrorCategory {
    Image(ImageError),         // the bytes are the problem
    Request(RequestError),     // the caller's request is the problem
    Resource(ResourceError),   // a cap was hit, or allocation failed
    Policy(PolicyKind),        // valid input a configured policy declined
    Lifecycle(enough::StopReason), // stopped via the Stop token
    Io(CodecIoKind),
    Internal(InternalKind),
}
```

with sub-enums `ImageError { Malformed, UnexpectedEof, Unsupported(UnsupportedImageKind) }`, `RequestError { Invalid(InvalidKind), Unsupported(UnsupportedOperation), CmsRequired }`, `ResourceError { Limits(LimitKind), OutOfMemory }`, `PolicyKind { Decode, Encode }`, `InternalKind { Bug, Dependency }`, and `From` shortcuts into `ErrorCategory` for ergonomic `category()` maps.

**Why:** a 13-codec ripgrep audit (`errorcategory-audit-2026-07-13.md`) found the flat "unsupported" axis conflated image-bytes-origin failures (a codec can't handle this bitstream) with invocation-origin failures (caller asked for an unsupported op/pixel format) at several call sites. The origin split makes that structurally unambiguous, and it collapses `is_incomplete_input_category` (the `check_decode_truncation_series` conformance policy from #112) to one `matches!(cat, ErrorCategory::Image(_))` instead of enumerating four flat variants.

## Policy and Internal also gained payloads

- `PolicyKind::{Decode, Encode}` mirrors the crate's existing `DecodePolicy`/`EncodePolicy` split — every policy rejection already happens on one side or the other of that boundary, so it costs nothing to plumb through, and it's a real logging/UX difference even though both map to HTTP 422 today.
- `InternalKind::{Bug, Dependency}` splits "a broken invariant in this codec's own logic" from "an unclassified error surfaced from a sub-component/foreign library" — both still mean 500 for routing, but the split lets telemetry that only carries the category forward (no per-codec downcast) distinguish code-defect from classification-gap from production traffic. `Dependency` is documented as a gap to close, not a legitimate permanent home, to avoid inviting `Internal` to stay the dumping ground the audit found it already is in several codecs.

## Other changes bundled in

- `Lifecycle` carries `enough::StopReason` directly — no re-derived enum; the stop reason *is* the payload, so `StopReason::category()` is a zero-cost `Lifecycle(*self)` and any future `#[non_exhaustive]` reason flows through unchanged.
- `LimitKind` gains `Scans` (progressive-decode scan-count ceiling) and `DecompressionRatio` (compression-bomb ceiling, security-relevant, distinct from an absolute `Memory` cap) — both structural caps the audit found had no home in the old set.
- Fixed a new-in-1.97.0 clippy `byte_char_slices` lint in `format/builtins.rs` while in the neighborhood.
- `zencodec-testkit` updated in lockstep: `is_incomplete_input_category`, the `reference` codec's `category()` map, and the "all categories" policy test (now exercises both `PolicyKind` and both `InternalKind` values).
- `docs/error-taxonomy-inventory.md` / `error-types-ecosystem.md` keep their 2026-06-24 snapshot (the per-codec audit that justified the category set) with a superseded-shape note pointing at `docs/spec.md` for the current form.
- `README.md` / `docs/spec.md` rewritten to the new shape; CHANGELOG `[Unreleased]` entry updated in place (not duplicated).

## Test plan

- [x] `cargo test --workspace` — 535+ lib tests + testkit suites + all doctests, all pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo semver-checks check-release` — no update required (still 0.1.25; `ErrorCategory`'s flat shape was never published, so nothing to break)
- [ ] Downstream: consuming codecs (zenjpeg/zenpng/zenwebp/zengif/zenjxl already patch to a zencodec git rev pending 0.1.26 — this branch's tip becomes the new pin) rewire their `category()` maps to the two-level shape (tracked separately, Phase 2/3 of the reshape)