### PR TITLE
feat(fidelity): add ApproxZensimB lossy target (ZensimProfile::B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,21 @@ All notable changes to zencodec are documented here.
   rather than inspecting raw CICP/ICC fields.
 
 ### Added
+- **`Fidelity::zensim_b` / `LossyTarget::ApproxZensimB(f32)`** — a fourth
+  one-shot lossy target, aiming at a zensim score (≈0–100, higher is better) in
+  a single calibrated pass. Pinned to `zensim::ZensimProfile::B` specifically
+  (the deterministic linear generation-B profile — a closed-form lasso fit,
+  byte-reproducible with no training seed) rather than "whichever zensim
+  profile is latest," so the target stays stable across zensim patch releases
+  the same way `ApproxSsim2` / `ApproxButteraugli` do. zensim was previously
+  noted as deferred ("no reliable metric yet") pending exactly this kind of
+  deterministic, non-MLP profile; `B` (shipped in zensim 0.3.0) is what
+  unblocks it. Additive: new enum variant on the already-`#[non_exhaustive]`
+  `LossyTarget`, new constructor, no signature changes. The default
+  `with_fidelity` fallback treats it like `ApproxSsim2` (passes the raw 0–100
+  score through to `with_generic_quality`) since zencodec has no built-in
+  zensim-to-generic-quality calibration curve — codecs override to honor it
+  natively, same as the other metric targets.
 - **zencodec-testkit: error-envelope conformance + whereat-trace checks** —
   `check_decode_error_envelope` (runtime: drives a decoder through dyn-dispatch
   erasure on rejected input, asserts the `ErrorCategory` *and* codec name survive

--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ let cfg = my_encoder_config
     .with_fidelity(Fidelity::Lossless);              // mathematically exact
 //  .with_fidelity(Fidelity::ssim2(90.0))            // aim at SSIMULACRA2 ~= 90
 //  .with_fidelity(Fidelity::butteraugli(1.0))       // aim at butteraugli max-norm ~= 1.0
+//  .with_fidelity(Fidelity::zensim_b(90.0))         // aim at zensim (ZensimProfile::B) ~= 90
 //  .with_fidelity(Fidelity::codec_quality(85.0));   // the codec's own native dial
 ```
 
@@ -314,6 +315,9 @@ let cfg = my_encoder_config
 
 - **`ApproxSsim2(score)`** — a one-shot SSIMULACRA2 target (a real cross-codec metric).
 - **`ApproxButteraugli(distance)`** — a one-shot butteraugli max-norm distance.
+- **`ApproxZensimB(score)`** — a one-shot zensim target, pinned to `ZensimProfile::B` (the
+  deterministic linear profile — stable across zensim patch releases, unlike the
+  deprecated MLP-based `A`).
 - **`CodecSpecificQuality(q)`** — the codec's own native quality scale (meaning differs per codec).
 
 These are **blind, single-pass**: the target maps to a native dial in one encode,

--- a/src/fidelity.rs
+++ b/src/fidelity.rs
@@ -3,8 +3,8 @@
 //! [`Fidelity`] is the encode-fidelity request. Two variants ship today:
 //! - **[`Lossless`](Fidelity::Lossless)** — mathematically exact.
 //! - **[`Lossy`](Fidelity::Lossy)** — aiming at a one-shot [`LossyTarget`] (a
-//!   SSIMULACRA2 score, a butteraugli max-norm distance, or the codec's own
-//!   native quality dial).
+//!   SSIMULACRA2 score, a butteraugli max-norm distance, a zensim score, or the
+//!   codec's own native quality dial).
 //!
 //! A third variant — **`LosslessMode`**: lossless *coding* (predictive, no DCT
 //! ringing) of pixels pre-quantized within a budget — is **designed but
@@ -50,6 +50,13 @@ impl Fidelity {
         Self::Lossy(LossyTarget::ApproxButteraugli(distance))
     }
 
+    /// Lossy, aiming at a zensim score (`zensim::ZensimProfile::B`) via a single
+    /// calibrated pass.
+    #[must_use]
+    pub const fn zensim_b(score: f32) -> Self {
+        Self::Lossy(LossyTarget::ApproxZensimB(score))
+    }
+
     /// Lossy, on the codec's own native quality scale (codec-specific meaning —
     /// see [`LossyTarget::CodecSpecificQuality`]).
     #[must_use]
@@ -88,11 +95,13 @@ impl Fidelity {
 
 /// What a lossy encode aims at.
 ///
-/// Three things we can target **today**, each in a single blind pass (no
+/// Four things we can target **today**, each in a single blind pass (no
 /// re-encode):
 /// - [`ApproxSsim2`](Self::ApproxSsim2) — a SSIMULACRA2 score.
 /// - [`ApproxButteraugli`](Self::ApproxButteraugli) — a butteraugli
 ///   **max-norm** distance (worst-region; lower is better).
+/// - [`ApproxZensimB`](Self::ApproxZensimB) — a zensim score on the
+///   `ZensimProfile::B` scale.
 /// - [`CodecSpecificQuality`](Self::CodecSpecificQuality) — the codec's own
 ///   native quality dial, honest that its meaning differs per codec.
 ///
@@ -107,8 +116,7 @@ impl Fidelity {
 /// value is hit), so loop targeting can be added later without renaming the
 /// one-shot arms. We target the butteraugli **max-norm** here; the **3-norm**
 /// aggregate is reserved as a separate arm (the two norms differ — a bare
-/// `Distance(f32)` is ambiguous and is never an arm). zensim is deferred — no
-/// reliable metric yet.
+/// `Distance(f32)` is ambiguous and is never an arm).
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[non_exhaustive]
 pub enum LossyTarget {
@@ -123,6 +131,18 @@ pub enum LossyTarget {
     /// without a norm suffix — max-norm is the standardized butteraugli target;
     /// the 3-norm aggregate is reserved as its own arm.
     ApproxButteraugli(f32),
+    /// Aim for a zensim score (≈0–100, higher is better) in a single calibrated
+    /// pass — no re-encode. Pinned to `zensim::ZensimProfile::B` specifically
+    /// (not "whichever profile is latest"): `B` is a **deterministic linear**
+    /// profile — a closed-form lasso fit, byte-reproducible with no training
+    /// seed — unlike the deprecated MLP-based `A`, so a target expressed
+    /// against it is stable across zensim patch releases the way this crate's
+    /// other metric targets are. "Approx" marks it blind one-shot, matching
+    /// `ApproxSsim2` / `ApproxButteraugli`; a closed-loop variant can be added
+    /// later without renaming this. If a future zensim generation supersedes
+    /// `B` as the recommended profile, that becomes a new sibling arm here —
+    /// this one keeps meaning "generation-B" for as long as it exists.
+    ApproxZensimB(f32),
     /// The codec's **native** quality dial, on its own scale. The meaning is
     /// codec-specific — there is no cross-codec standard here (unlike a metric
     /// target). Use when you know the codec and want its raw knob.
@@ -195,6 +215,7 @@ mod tests {
         assert!(Fidelity::Lossless.is_lossless());
         assert!(!Fidelity::ssim2(90.0).is_lossless());
         assert!(!Fidelity::butteraugli(1.0).is_lossless());
+        assert!(!Fidelity::zensim_b(90.0).is_lossless());
         assert!(!Fidelity::codec_quality(90.0).is_lossless());
     }
 
@@ -207,6 +228,10 @@ mod tests {
         assert_eq!(
             Fidelity::butteraugli(1.0),
             Fidelity::Lossy(LossyTarget::ApproxButteraugli(1.0))
+        );
+        assert_eq!(
+            Fidelity::zensim_b(90.0),
+            Fidelity::Lossy(LossyTarget::ApproxZensimB(90.0))
         );
         assert_eq!(
             Fidelity::codec_quality(85.0),

--- a/src/format/builtins.rs
+++ b/src/format/builtins.rs
@@ -140,7 +140,7 @@ fn detect_jxl(data: &[u8]) -> bool {
     // Container: 00 00 00 0C 4A 58 4C 20 0D 0A 87 0A
     data.len() >= 12
         && data[..4] == [0x00, 0x00, 0x00, 0x0C]
-        && data[4..8] == [b'J', b'X', b'L', b' ']
+        && data[4..8] == *b"JXL "
         && data[8..12] == [0x0D, 0x0A, 0x87, 0x0A]
 }
 

--- a/src/traits/encoding.rs
+++ b/src/traits/encoding.rs
@@ -142,10 +142,12 @@ pub trait EncoderConfig: Clone + Send + Sync {
             // codec-agnostic → 0–100 conversion, so the default just selects
             // lossy and leaves quality at the codec default (visible through
             // `resolved_target_fidelity`). Codecs override to honor butteraugli
-            // / SSIM2 / their native scale precisely.
-            Fidelity::Lossy(LossyTarget::ApproxSsim2(q) | LossyTarget::CodecSpecificQuality(q)) => {
-                self.with_lossless(false).with_generic_quality(q)
-            }
+            // / SSIM2 / zensim / their native scale precisely.
+            Fidelity::Lossy(
+                LossyTarget::ApproxSsim2(q)
+                | LossyTarget::ApproxZensimB(q)
+                | LossyTarget::CodecSpecificQuality(q),
+            ) => self.with_lossless(false).with_generic_quality(q),
             Fidelity::Lossy(LossyTarget::ApproxButteraugli(_)) => self.with_lossless(false),
             Fidelity::Lossless => self.with_lossless(true),
         }


### PR DESCRIPTION
## Summary

- Adds `Fidelity::zensim_b(score: f32)` / `LossyTarget::ApproxZensimB(f32)` — a fourth one-shot lossy target (alongside `ApproxSsim2` / `ApproxButteraugli` / `CodecSpecificQuality`), aiming at a zensim score (≈0–100, higher is better) in a single calibrated pass.
- Pinned to `zensim::ZensimProfile::B` specifically — the deterministic linear generation-B profile shipped in zensim 0.3.0 (a closed-form lasso fit, byte-reproducible with no training seed) — rather than "whichever zensim profile is latest," so the target stays stable across zensim patch releases the same way `ApproxSsim2`/`ApproxButteraugli` do.
- zensim was previously documented in `fidelity.rs` as deferred ("no reliable metric yet") specifically pending a deterministic, non-MLP profile. `B` is what unblocks it — the deprecated MLP-based `A` would have been the wrong thing to pin a public API to (training-seed variance).

## Why now

Purely additive — new variant on the already-`#[non_exhaustive]` `LossyTarget`, new constructor, no signature changes to anything existing. Also updated the internal `with_fidelity` default-fallback match in `traits/encoding.rs` to route `ApproxZensimB` through the same raw-score passthrough as `ApproxSsim2` (zencodec has no built-in zensim→generic-quality calibration curve; codecs override to honor it natively — same pattern as the other metric targets).

Bundled: fixed the same new-in-1.97.0 clippy `byte_char_slices` lint in `format/builtins.rs` already fixed independently on the `caterr-reshape` PR (#116) — pre-existing issue, unrelated to this feature, trivial enough to include rather than leave this PR's CI clippy-warned.

## Test plan

- [x] `cargo test --workspace` — 535+ lib tests + testkit suites + doctests, all pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo semver-checks check-release` — no update required (additive)