### PR TITLE
feat: CodecSet multi-codec registry, one-shot trait methods, prelude (0.1.27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,17 +101,29 @@ removes that whole class).
 - One-shot provided methods on the config traits: `DecoderConfig::decode`,
   `DecoderConfig::probe`, and `EncoderConfig::encode` — single-line
   config→result use with default job settings (08dabea).
+- Job-level one-shot encode: `EncodeJob::encode(pixels)` /
+  `DynEncodeJob::encode(pixels)` — configure a job (metadata, limits, policy),
+  then encode in one call instead of the two-step `job.encoder()?.encode(pixels)`
+  / `job.into_encoder()?.encode(pixels)`. Provided methods (adding them broke no
+  implementor); the job-level analog of `EncoderConfig::encode`, which encodes
+  with *default* settings.
 - `zencodec::prelude` — one-import bundle of every encode/decode trait,
   generic and dyn (0edaf64).
 - testkit: `CodecSet` behavior suite against the reference codec — roundtrip,
   registration-scoped detection, custom-format detect→decode, static
   `LazyLock` sharing across threads, template cloning, typed errors (a4fec14).
+- testkit: `ReferenceZcrDecoderConfig` + `ZCR_FORMAT` — the reference decoder
+  registered under a self-detecting format (matches the codec's own `ZCR1` wire
+  magic) instead of `ImageFormat::Pnm`. Drop-in for `ReferenceDecoderConfig` so
+  detection-based decode (`decode` / `probe` / `estimate_decode_of`) works end to
+  end; removes the ~35-line custom-format scaffolding each detect→decode test and
+  example previously hand-rolled.
 - testkit: `tests/usage.rs` — worked, runnable examples of the common
   `CodecSet` usages (encode / decode / probe / app-wide sharing / fidelity +
-  metadata / pixel-format request / strip streaming / estimate) plus two
-  `zenpixels-convert`-assisted paths: adapting a foreign pixel format into an
-  encoder's supported set (`adapt_for_encode`) and converting a decoded buffer
-  to a caller-chosen format (`convert_to`).
+  metadata via the job's direct `encode` / pixel-format request / strip
+  streaming / estimate) plus two `zenpixels-convert`-assisted paths: adapting a
+  foreign pixel format into an encoder's supported set (`adapt_for_encode`) and
+  converting a decoded buffer to a caller-chosen format (`convert_to`).
 
 ### Deprecated
 - `ComputeEnvironment::new()` — construction should be explicit. Use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,16 @@ removes that whole class).
   limits / stop / policies are stamped onto every job; `encode_with(Fidelity)`
   clones the registered encoder template per call; `decode_job` / `encode_job`
   expose the stamped jobs for per-operation control (0edaf64).
+- `CodecSet::transcode(input, target, fidelity, metadata_policy, color_policy)`
+  — the one-call proxy operation: decode → carry the source's metadata → encode.
+  Reads the source's ICC / EXIF / XMP / CICP / HDR / orientation off the decode
+  result (via `Metadata::from(&ImageInfo)`, with orientation reconciliation),
+  re-embeds under the `MetadataPolicy` (`Web` strips privacy / `PreserveExact`
+  keeps all), and applies a `ColorEmitPolicy` for color signaling. Single-image,
+  no pixel processing, no descriptor adaptation — a source→target pair whose
+  decoder-output and encoder-input descriptors are disjoint surfaces the
+  encoder's error rather than corrupting (this crate carries no pixel-conversion
+  dep; the common zen codecs bridge on sRGB RGBA8/RGB8).
 - `CodecSet::estimate_encode` / `estimate_decode` — by-format resource
   estimate (peak memory / wall-time / core-scaling) forwarding to the
   registered codec's `estimate_{encode,decode}_resources`, so a `CodecSet`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,11 @@ removes that whole class).
   limits / stop / policies are stamped onto every job; `encode_with(Fidelity)`
   clones the registered encoder template per call; `decode_job` / `encode_job`
   expose the stamped jobs for per-operation control (0edaf64).
+- `CodecSet::estimate_encode` / `estimate_decode` — by-format resource
+  estimate (peak memory / wall-time / core-scaling) forwarding to the
+  registered codec's `estimate_{encode,decode}_resources`, so a `CodecSet`
+  covers estimation too; `NoEncoder` / `NoDecoder` when the format has no
+  registered codec.
 - One-shot provided methods on the config traits: `DecoderConfig::decode`,
   `DecoderConfig::probe`, and `EncoderConfig::encode` — single-line
   config→result use with default job settings (08dabea).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ removes that whole class).
 - Remove `SourceColor::has_hdr_transfer()` — moves to a pipeline-level
   utility that consults `ColorProfileSource` and `HdrPolicy` together
   rather than inspecting raw CICP/ICC fields.
+- Remove `ComputeEnvironment::new()` (deprecated in 0.1.27) — construction
+  goes through the explicit `conservative()` / `host()` constructors.
 
 ### Added
 - `CodecSet` / `CodecSetError` — multi-codec registry: register decoder /
@@ -88,6 +90,11 @@ removes that whole class).
   registered codec. `estimate_decode_of(data, compute)` probes the input
   first (format + dimensions) and estimates in the decoder's native output
   format — the bytes-based convenience, as one-call as `probe`.
+- `ComputeEnvironment::conservative()` / `ComputeEnvironment::host()` — explicit
+  estimate-environment constructors. `conservative()` is the single-core
+  baseline (the old `new()` behavior, now explicitly named); `host()` (std)
+  detects the running machine (`available_parallelism()` cores +
+  `SimdTier::CurrentHost`; RAM left unknown — std has no portable query).
 - One-shot provided methods on the config traits: `DecoderConfig::decode`,
   `DecoderConfig::probe`, and `EncoderConfig::encode` — single-line
   config→result use with default job settings (08dabea).
@@ -96,6 +103,11 @@ removes that whole class).
 - testkit: `CodecSet` behavior suite against the reference codec — roundtrip,
   registration-scoped detection, custom-format detect→decode, static
   `LazyLock` sharing across threads, template cloning, typed errors (a4fec14).
+
+### Deprecated
+- `ComputeEnvironment::new()` — construction should be explicit. Use
+  `conservative()` (the single-core baseline, identical behavior) or `host()`
+  (std, detect the running machine). Removal is queued for the next 0.x minor.
 
 ## [0.1.26] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,9 @@ removes that whole class).
   estimate (peak memory / wall-time / core-scaling) forwarding to the
   registered codec's `estimate_{encode,decode}_resources`, so a `CodecSet`
   covers estimation too; `NoEncoder` / `NoDecoder` when the format has no
-  registered codec.
+  registered codec. `estimate_decode_of(data, compute)` probes the input
+  first (format + dimensions) and estimates in the decoder's native output
+  format — the bytes-based convenience, as one-call as `probe`.
 - One-shot provided methods on the config traits: `DecoderConfig::decode`,
   `DecoderConfig::probe`, and `EncoderConfig::encode` — single-line
   config→result use with default job settings (08dabea).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,10 +89,11 @@ removes that whole class).
   result (via `Metadata::from(&ImageInfo)`, with orientation reconciliation),
   re-embeds under the `MetadataPolicy` (`Web` strips privacy / `PreserveExact`
   keeps all), and applies a `ColorEmitPolicy` for color signaling. Single-image,
-  no pixel processing, no descriptor adaptation — a source→target pair whose
-  decoder-output and encoder-input descriptors are disjoint surfaces the
-  encoder's error rather than corrupting (this crate carries no pixel-conversion
-  dep; the common zen codecs bridge on sRGB RGBA8/RGB8).
+  no pixel processing. Decodes *preferring* the target encoder's input
+  descriptors, so decoder and encoder meet on a shared pixel format with no
+  adaptation; a pair errors (rather than corrupting) only when their supported
+  descriptor sets are disjoint (this crate carries no pixel-conversion dep — the
+  common raster codecs bridge on sRGB RGB8/RGBA8).
 - `CodecSet::estimate_encode` / `estimate_decode` — by-format resource
   estimate (peak memory / wall-time / core-scaling) forwarding to the
   registered codec's `estimate_{encode,decode}_resources`, so a `CodecSet`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@ removes that whole class).
   registered codec. `estimate_decode_of(data, compute)` probes the input
   first (format + dimensions) and estimates in the decoder's native output
   format — the bytes-based convenience, as one-call as `probe`.
+  `estimate_encode_of(format, pixels, compute)` is the encode analog — it
+  reads the dimensions and format straight off the pixel slice you already
+  hold, no `ImageCharacteristics` to build by hand.
 - `ComputeEnvironment::conservative()` / `ComputeEnvironment::host()` — explicit
   estimate-environment constructors. `conservative()` is the single-core
   baseline (the old `new()` behavior, now explicitly named); `host()` (std)
@@ -103,6 +106,12 @@ removes that whole class).
 - testkit: `CodecSet` behavior suite against the reference codec — roundtrip,
   registration-scoped detection, custom-format detect→decode, static
   `LazyLock` sharing across threads, template cloning, typed errors (a4fec14).
+- testkit: `tests/usage.rs` — worked, runnable examples of the common
+  `CodecSet` usages (encode / decode / probe / app-wide sharing / fidelity +
+  metadata / pixel-format request / strip streaming / estimate) plus two
+  `zenpixels-convert`-assisted paths: adapting a foreign pixel format into an
+  encoder's supported set (`adapt_for_encode`) and converting a decoded buffer
+  to a caller-chosen format (`convert_to`).
 
 ### Deprecated
 - `ComputeEnvironment::new()` — construction should be explicit. Use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,11 +89,13 @@ removes that whole class).
   result (via `Metadata::from(&ImageInfo)`, with orientation reconciliation),
   re-embeds under the `MetadataPolicy` (`Web` strips privacy / `PreserveExact`
   keeps all), and applies a `ColorEmitPolicy` for color signaling. Single-image,
-  no pixel processing. Decodes *preferring* the target encoder's input
-  descriptors, so decoder and encoder meet on a shared pixel format with no
-  adaptation; a pair errors (rather than corrupting) only when their supported
-  descriptor sets are disjoint (this crate carries no pixel-conversion dep — the
-  common raster codecs bridge on sRGB RGB8/RGBA8).
+  no pixel processing. Precision-preserving: decodes at the source's native
+  descriptor and encodes it verbatim when the target accepts it (a 16-bit / HDR
+  source is not flattened to 8-bit when the target can carry it), re-decoding to
+  bridge only when the native descriptor is unsupported. A pair errors (rather
+  than corrupting) only when the decoder and encoder supported descriptor sets
+  are disjoint (this crate carries no pixel-conversion dep — the common raster
+  codecs bridge on sRGB RGB8/RGBA8).
 - `CodecSet::estimate_encode` / `estimate_decode` — by-format resource
   estimate (peak memory / wall-time / core-scaling) forwarding to the
   registered codec's `estimate_{encode,decode}_resources`, so a `CodecSet`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,26 @@ removes that whole class).
   utility that consults `ColorProfileSource` and `HdrPolicy` together
   rather than inspecting raw CICP/ICC fields.
 
+### Added
+- `CodecSet` / `CodecSetError` — multi-codec registry: register decoder /
+  encoder configs one line each and get detect→decode, `probe`, push /
+  streaming / animation decode, and format-keyed encode through one
+  `Send + Sync + 'static` handle whose operations all take `&self` — build it
+  once and share it app-wide (`LazyLock` / `OnceLock` / `Arc`). Detection
+  derives from the registered decoders in `ImageFormatRegistry::common()`
+  priority order (custom formats after, in registration order); set-level
+  limits / stop / policies are stamped onto every job; `encode_with(Fidelity)`
+  clones the registered encoder template per call; `decode_job` / `encode_job`
+  expose the stamped jobs for per-operation control (0edaf64).
+- One-shot provided methods on the config traits: `DecoderConfig::decode`,
+  `DecoderConfig::probe`, and `EncoderConfig::encode` — single-line
+  config→result use with default job settings (08dabea).
+- `zencodec::prelude` — one-import bundle of every encode/decode trait,
+  generic and dyn (0edaf64).
+- testkit: `CodecSet` behavior suite against the reference codec — roundtrip,
+  registration-scoped detection, custom-format detect→decode, static
+  `LazyLock` sharing across threads, template cloning, typed errors (a4fec14).
+
 ## [0.1.26] - 2026-07-14
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "3"
 
 [package]
 name = "zencodec"
-version = "0.1.26"
+version = "0.1.27"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0 OR MIT"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ types (metadata, limits, format detection, color emission) at the root.
 
 ```toml
 [dependencies]
-zencodec = "0.1.26"
+zencodec = "0.1.27"
 ```
 
 zencodec defines the traits; a concrete codec crate (here `zenjpeg`) supplies the
@@ -41,6 +41,53 @@ let pixels = decoded.into_buffer();
 
 For untrusted input, attach a resource limit and a cancellation token to the
 **job** — see [Untrusted input](#untrusted-input-limits-cancellation-errors) below.
+
+### One-shots
+
+When default job settings are fine, each config trait ships one-shot
+conveniences — `EncoderConfig::encode`, `DecoderConfig::decode` / `probe`:
+
+```rust,ignore
+let jpeg = JpegEncoderConfig::new().with_generic_quality(85.0).encode(pixels)?;
+let info = JpegDecoderConfig::new().probe(jpeg.data())?;   // header only
+let image = JpegDecoderConfig::new().decode(jpeg.data())?; // full decode
+```
+
+`use zencodec::prelude::*;` brings every encode/decode trait into scope in one
+line.
+
+### Multi-codec: `CodecSet`
+
+To handle several formats behind one handle, register configs in a
+[`CodecSet`]: each decoder announces its own formats, magic-byte detection
+derives from what's registered (in the curated priority order — AVIF before
+HEIC, DNG before TIFF), and encoding is keyed by `ImageFormat`. The set is
+`Send + Sync` with `&self` operations, so build it once — in a
+`LazyLock`/`OnceLock` static or an `Arc` — and share it app-wide:
+
+```rust,ignore
+use std::sync::LazyLock;
+use zencodec::{CodecSet, ImageFormat, ResourceLimits};
+
+static CODECS: LazyLock<CodecSet> = LazyLock::new(|| {
+    CodecSet::new()
+        .with_limits(ResourceLimits::default())
+        .with_decoder(zenjpeg::JpegDecoderConfig::new())
+        .with_decoder(zenpng::PngDecoderConfig::new())
+        .with_encoder(zenjpeg::JpegEncoderConfig::new().with_generic_quality(85.0))
+});
+
+let image = CODECS.decode(&bytes)?;                            // detect → decode
+let jpeg  = CODECS.encode(ImageFormat::Jpeg, image.pixels())?; // format-keyed
+```
+
+Limits, stop tokens, and policies set on the set are stamped onto every job it
+creates; `decode_job` / `encode_job` expose the underlying job for
+per-operation control (decode hints, metadata, animation). Per-call quality
+goes through `encode_with(format, Fidelity, pixels)`, which clones the
+registered template.
+
+[`CodecSet`]: https://docs.rs/zencodec/latest/zencodec/struct.CodecSet.html
 
 ## Crates in the zen\* family
 
@@ -408,7 +455,8 @@ let plan = resolve_color_emit(&source_color, &target_caps, ColorEmitPolicy::Bala
 | `zencodec::gainmap` | `GainMapInfo`, `GainMapParams`, `GainMapChannel`, `GainMapDirection`, `GainMapPresence`, `Iso21496Format` (wire-format variant: `AvifTmap`, `JxlJhgm`, `JpegApp2BodyWithUrn`; the original `JpegApp2` is deprecated since 0.1.20), `ISO_21496_1_URN`, `ISO_21496_1_PRIMARY_APP2_BODY`, `serialize_iso21496_fmt` / `serialize_iso21496_fmt_into` / `parse_iso21496_fmt`, `GainMapParseError` — cross-codec gain map types and wire-format helpers (ISO 21496-1) |
 | `zencodec::exif` | Structured EXIF/TIFF: `Exif` (borrowing parse → prune → serialize), `ExifPolicy` (7 keep/discard categories), `Retention`, `ByteOrder`, `retain` |
 | `zencodec::helpers` | Codec implementation helpers (not consumer API) — shared boilerplate for trait implementors, plus the lightweight `parse_exif_orientation` accessor |
-| root | `ImageFormat`, `ImageFormatDefinition`, `ImageFormatRegistry` (format detection via `ImageFormatRegistry::detect()`), `ImageInfo`, `Metadata`, `MetadataPolicy`, `MetadataFields`, `IccRetention`, `Exif`, `ExifPolicy`, `Retention`, `ByteOrder`, `Orientation`, `OrientationHint`, `ResourceLimits`, `AllocPreference`, `LimitExceeded`, `ThreadingPolicy`, `UnsupportedOperation`, `CodecErrorExt`, `find_cause`, `Unsupported`, `Extensions`, `AnimationFrame`, `OwnedAnimationFrame`, `resolve_color_emit`, `ColorEmitPolicy`, `ColorEmitPlan`, `ColorEmitFields`, `IccDisposition`, `CicpEmission`, `ColorAuthority`, `Cicp`, `ContentLightLevel`, `MasteringDisplay`, `StopToken`, `Unstoppable` |
+| `zencodec::prelude` | One-import bundle of every encode/decode trait (generic + dyn) |
+| root | `CodecSet` / `CodecSetError` (multi-codec registry: registration-derived detection, format-keyed encode, shareable app-wide), `ImageFormat`, `ImageFormatDefinition`, `ImageFormatRegistry` (format detection via `ImageFormatRegistry::detect()`), `ImageInfo`, `Metadata`, `MetadataPolicy`, `MetadataFields`, `IccRetention`, `Exif`, `ExifPolicy`, `Retention`, `ByteOrder`, `Orientation`, `OrientationHint`, `ResourceLimits`, `AllocPreference`, `LimitExceeded`, `ThreadingPolicy`, `UnsupportedOperation`, `CodecErrorExt`, `find_cause`, `Unsupported`, `Extensions`, `AnimationFrame`, `OwnedAnimationFrame`, `resolve_color_emit`, `ColorEmitPolicy`, `ColorEmitPlan`, `ColorEmitFields`, `IccDisposition`, `CicpEmission`, `ColorAuthority`, `Cicp`, `ContentLightLevel`, `MasteringDisplay`, `StopToken`, `Unstoppable` |
 
 zencodec has no feature flags. The full API is always available.
 

--- a/docs/pixel-descriptor-negotiation.md
+++ b/docs/pixel-descriptor-negotiation.md
@@ -1,0 +1,282 @@
+# Pixel-descriptor probe certainty & source-aware negotiation
+
+**Provenance:** 8 parallel source surveys of the sibling codec crates,
+2026-07-14, against zencodec @ `edc02c7` (`codecset`) and each codec's local
+`main`. Every claim below is traced to `file:line`; see §7. This doc backs the
+single-decode, precision-preserving transcode work (`CodecSet::transcode`).
+
+---
+
+## TL;DR
+
+1. **There are two different "source descriptors", and only one is authoritative.**
+   - The **decoder-native** descriptor: the exact `PixelDescriptor` the decoder
+     will produce for *this* image, derived from the parsed header (bit depth
+     incl. float-ness, channels, alpha, transfer/primaries). Every decoder
+     computes this internally. It is exact.
+   - The **probe-reconstructed** descriptor: what you can rebuild from
+     `ImageInfo.source_color`'s scalar fields (`bit_depth: Option<u8>`,
+     `channel_count`, `cicp`, …). Best-effort, lossy, and for some codecs
+     absent or undefined.
+2. **Negotiate in the decoder, using the native descriptor — never
+   reconstruct-from-probe-then-negotiate.** The probe loses information the
+   negotiation needs (float-vs-int, RAW's decoder-decided output, GIF's
+   unpopulated depth). JXL already does exactly this and is the reference.
+3. **Lift JXL's `choose_pixel_format` / `can_produce_losslessly`
+   (`zenjxl decode.rs:391-475`) into one shared
+   `negotiate_pixel_format(source, preferred, available)`.** It is the validated
+   "widen-only, never narrow, native fallback that never flattens" algorithm.
+   Today's shared helper (`zencodec negotiate.rs:49`) takes no `source` at all —
+   that is the whole bug.
+4. **Encode `supported_descriptors()` must mean the *fidelity envelope*, not the
+   accept-and-convert set.** WebP, GIF, JPEG and AVIF all advertise `*F32`
+   (and JPEG/PNG advertise 16-bit) descriptors they silently downconvert. Feeding
+   those to "preserve precision" is pure memory bloat with silent loss.
+
+---
+
+## 1. Can every probe emit a *certain* source descriptor?
+
+**No — but the codecs that can't are exactly the ones where it doesn't block
+negotiation**, because negotiation runs in the decoder off the native descriptor,
+not off probe. Probe's `source_descriptor` is a transparency bonus with per-codec
+confidence. Three tiers:
+
+| Tier | Meaning | Codecs |
+|------|---------|--------|
+| **1 — Certain** | Full descriptor from header (or structurally fixed); safe to expose at probe | farbfeld, QOI, PNM, HDR/RGBE, **PNG**, AVIF*, HEIC† |
+| **2 — Certain-for-common, caveated** | Right for the common case; a named axis is missing or assumed | JPEG, WebP, JXL, BMP, TGA |
+| **3 — Cannot emit at probe** | No source descriptor is produced / definable pre-decode | GIF, RAW/DNG |
+
+\* AVIF: certain for real-world HDR (bit depth from `av1C`, transfer/primaries
+from `nclx`), but falls back to sRGB when the `colr` box is absent.
+† HEIC: `probe()` is certain on depth + PQ/HLG transfer; ICC + `clli`/`mdcv`
+need the heavier `probe_full()`.
+
+**Per-codec probe verdict** (can probe populate `ImageInfo.source_descriptor`?):
+
+| Format | Verdict | depth | channels | alpha | color/HDR | Notable gap |
+|--------|---------|-------|----------|-------|-----------|-------------|
+| farbfeld | ✓ fixed | 16 ✓ | 4 ✓ | ✓(always) | sRGB assumed | primaries assumed |
+| QOI | ✓ | 8 ✓ | ✓(header) | ✓(header) | colorspace byte ✓ | — |
+| PNM | ✓ | 8/16/32 ✓ | ✓ | ✓ | PFM linear ✓, else sRGB | no ICC/CICP in format |
+| HDR/RGBE | ✓ fixed | 32(f32) ✓ | 3 ✓ | ✗(none) | linear ✓ | primaries assumed |
+| **PNG** | ✓ **strong** | 1/2/4/8/16 ✓ | ✓ | **✓ all types incl tRNS (pre-IDAT)** | cICP+iCCP ✓, HDR ✓ | gAMA/cHRM parsed-but-dropped; `cLLI` casing bug |
+| AVIF | ⚠→✓ | 8/10/12 ✓(av1C) | ✓ | ✓(auxl) | nclx CICP ✓, clli/mdcv ✓ | nclx-absent→sRGB; no diffuse_white |
+| HEIC | ⚠/✓_full | 8/10/12 ✓(hvcC) | ⚠(mono not surfaced) | ✓(aux URN) | CICP ✓; ICC+clli/mdcv only in probe_full | mono→reports 3ch |
+| JPEG | ⚠ | 8/12 ✓ | 1/3/4 ✓ | ✓(=false) | ICC raw ✓; no CICP | color-model/subsampling/gain-map computed-but-dropped |
+| WebP | ⚠ | 8 ✓(invariant) | ⚠(3-v-4 only) | ✓ | ICC ✓; no CICP | **blind to grayscale** (stored as YUV/ARGB) |
+| JXL | ⚠ | count ✓ | ✓ | ✓ | cicp+ICC ✓ | **float-vs-int lost** (inferred `bits==32`); no diffuse_white/mastering at probe |
+| BMP | ⚠ | bpp ✓(per-pixel) | ⚠(post-palette) | ⚠(32-bit assumed) | sRGB assumed | bpp≠per-channel |
+| TGA | ⚠ | ⚠(color-mapped under-reports) | ⚠ | ⚠(32-bit assumed) | sRGB assumed | — |
+| GIF | ✗ | **None** | **None** | ⚠(full frame-walk; true-on-fail) | sRGB assumed | emits **no** descriptor; `cheap_probe=false` |
+| RAW/DNG | ✗ | ⚠ **estimated** sensor depth | ✗ None | ✗(none) | ✗ | **decoder-decides output**; sensor≠output |
+
+**RAW is the instructive outlier:** its sensor depth (12/14/16, itself only
+*estimated* from the white level) is never the output precision. Output is RGB16
+or RGBF32 chosen by `OutputMode` + `preferred` at decode time. So for RAW the
+"source descriptor" can only mean the **decoded-faithful** descriptor (RGB16 /
+RGBF32), never the mosaic. That is the general rule: **source descriptor = the
+most faithful decoded representation, not the container encoding.**
+
+---
+
+## 2. Descriptor capability matrix
+
+What each codec can **produce** (decode) and its true **fidelity ceiling**
+(encode) — the honest max it stores, after seeing through accept-and-downconvert.
+
+| Format | Decode produces (max) | Encode fidelity ceiling | Alpha | HDR | Gray |
+|--------|----------------------|-------------------------|-------|-----|------|
+| **JXL** | U8/U16/**F32** × {Gray,GrayA,RGB,RGBA} | 8-/16-int + **F32** + HDR (intensity_target) + wide-gamut/PQ/HLG | ✓ | ✓ | ✓ |
+| **PNG** | 8/**16**-bit + F32(passthru) | **16-bit** (u16) + cICP HDR; F32→8 | ✓ | ✓(16+cICP) | ✓ |
+| **farbfeld** | **RGBA16** (fixed) | **RGBA16 bit-exact** | ✓(always) | ✗ | (widened in) |
+| **AVIF** | 8/**16**(10·12→u16) | **10-bit** + HDR(nclx+clli+mdcv); 16→10, F32-SDR→8 | ✓ | ✓(10-bit) | mono |
+| **HEIC** | 8/**16**(10→RGB16) | *(decode-only)* | ✓ | ✓ | (mono internal) |
+| **RAW/DNG** | RGB16 / **RGBF32** (config) | *(decode-only)* | ✗ | linear | — |
+| **HDR/RGBE** | **RGBF32_LINEAR** (fixed) | RGBE (~8-bit mantissa+shared exp — **f32 not bit-exact**) | ✗ | ✓ | ✗ |
+| **PNM** | 16(gray)·F32; **color-16→8** | 8-int **or** F32 (RGBA-F32 drops α); **no u16 out** | ✓ | PFM linear | ✓ |
+| **JPEG** | 8-bit (F32 promoted; **no 16**) | **8-bit, 1/3ch, NO alpha, NO HDR** | ✗(enc) | ✗ | ✓ |
+| **WebP** | 8-bit (RGB8/RGBA8/BGRA8) | **8-bit** sRGB(+ICC) | ✓ | ✗ | enc-in only |
+| **GIF** | 8-bit (forced RGBA8) | **8-bit indexed ≤256, 1-bit alpha** | 1-bit | ✗ | ✗(palette) |
+| **BMP** | 8-bit (RGB/RGBA/Gray) | **8-bit RGB/RGBA** (no gray, no 16) | ✓ | ✗ | dec-only |
+| **TGA** | 8-bit (RGB/RGBA/Gray) | **8-bit** | ✓ | ✗ | ✓ |
+| **QOI** | 8-bit (RGB/RGBA) | **8-bit lossless** (no gray) | ✓ | ✗ | ✗(enc) |
+
+Precision anchors: **farbfeld (16-bit RGBA)** and **HDR/RGBE + JXL/PNM (f32)**
+are the "high precision must survive" end; **GIF/WebP/JPEG/BMP/TGA/QOI (8-bit)**
+are the caps. AVIF is a 10-bit HDR pivot; note **12-bit is silently capped to
+10-bit** (ravif supports `Twelve`, the zenavif wrapper never invokes it).
+
+---
+
+## 3. The accept-and-downconvert (bloat) traps
+
+Descriptors an encoder **advertises** in `supported_descriptors()` but does **not**
+preserve — feeding them high precision wastes memory and silently loses data.
+This is why the encode envelope must be redefined as *fidelity*, not *accept*.
+
+| Format | Advertises (encode) | Actually preserved (fidelity envelope) | Lie |
+|--------|--------------------|----------------------------------------|-----|
+| WebP | +RGBF32,RGBAF32,GRAYF32 | 8-bit only | 3× F32 → 8-bit at input |
+| GIF | +RGBF32,RGBAF32,GRAYF32 | 8-bit indexed | 3× F32 → 8-bit at input |
+| JPEG | +RGB16,RGBA16,GRAY16,+3×F32,+RGBA/BGRA | 8-bit, no alpha | 16/F32 → 8-bit; alpha dropped |
+| PNG | +RGBF32,RGBAF32,GRAYF32 | 16-bit (u16 real) | F32 → 8-bit (defeats HDR; route HDR via u16) |
+| AVIF | +RGB16,RGBA16,+F32-SDR | 10-bit | 16→10; F32-SDR→8 |
+| JXL | — | 8/16-int + F32 (all real) | **none (honest)** |
+| farbfeld | — | RGBA16 (real) + widen-in | **none (honest)** |
+
+**Consequence for the navigator:** cap the target's usable precision at its
+fidelity ceiling *before* matching the source. A 16-bit source → WebP must
+negotiate to 8-bit (WebP's real ceiling), not be handed an f32 buffer WebP just
+downconverts — that is the "no bloat" guarantee, and it only works if the
+envelope tells the truth.
+
+---
+
+## 4. How decoders handle `preferred` today — 5-way inconsistent
+
+The single biggest structural finding: there is **no shared negotiation path**.
+
+| Codec(s) | `preferred` handling |
+|----------|----------------------|
+| **JXL** | ✅ source-aware: `choose_pixel_format` (widen-only, never narrow, native fallback). **The reference.** |
+| **AVIF, HEIC** | source-aware-ish: build a bit-depth-ordered `available` list (16-bit-first when >8), then the shared `negotiate_pixel_format`. Correct because the *list* is source-ordered. |
+| **PNG** | shared **precision-blind** `negotiate_pixel_format`: native on empty `preferred`, but a non-matching non-empty list **force-converts to RGB8 → flattens 16-bit/HDR**. ← the bug, live. |
+| **JPEG** | own `select_decode_descriptor`: source-aware on gray-vs-color only, **bit-depth-blind**. |
+| **GIF** | own `negotiate_format`: fixed priority RGB8>BGRA8>RGBA8, **forces RGBA8** default. |
+| **WebP** | own `negotiate_format`: only the lossless RGBA→BGRA swizzle; else ignores. |
+| **zenbitmaps ×6** | `decoder()` **ignores `preferred`** entirely (source-driven output); `preferred` only reaches the `push_decoder` sink path via `copy_decode_to_sink`. |
+
+A single source-aware `negotiate_pixel_format(source, preferred, available)`
+collapses all of these into one correct path. AVIF/HEIC keep their source-ordered
+`available` (or drop the manual ordering once the helper is source-aware). PNG's
+flatten disappears. JPEG/GIF/WebP replace their bespoke logic. zenbitmaps gain
+`preferred` support for free.
+
+---
+
+## 5. The navigator — one source-aware helper, run in the decoder
+
+### 5.1 Where negotiation runs
+
+**Inside the decoder**, off the *native* descriptor it just parsed — not
+reconstructed from probe. Justification is empirical: probe drops float-ness
+(JXL), can't define output pre-decode (RAW), and doesn't populate depth at all
+(GIF). The decoder always has the exact native descriptor (JXL proves the model).
+
+`ImageInfo.source_descriptor: Option<PixelDescriptor>` is added as a **best-effort
+transparency signal** — populated at probe where Tier-1/2 certain, `None` for
+Tier-3 — but negotiation never depends on it.
+
+### 5.2 The scorer (lifted from JXL, generalized)
+
+One function, used identically on both sides (decoder picks output, encoder picks
+input) — both ask "how well does candidate match source?":
+
+```
+negotiate_pixel_format(source, preferred, available) -> PixelDescriptor:
+
+  native = source                      # the decoder's exact native descriptor
+
+  # 1. Honor caller preference, first LOSSLESS producible (JXL's rule):
+  for want in preferred:
+      if can_produce_losslessly(native.channel_type, want.channel_type)   # widen-only
+         and layout_compatible(native.layout, want.layout)                 # no channel drop
+         and (want is not gray  or  native is gray)                        # gray-source guard
+         and want.transfer matches native (or unknown)                     # no transfer remap
+         and want.primaries ⊇ native.primaries:                            # no gamut clip
+          return the matching `available` entry
+
+  # 2. No preference (or none lossless) -> native precision+layout. NEVER flatten.
+  return best_available_matching(native)   # widen-only to nearest available; native if present
+
+can_produce_losslessly(native, target):    # verbatim from JXL decode.rs:465
+  U8  -> target in {U8, U16, F32}
+  U16 -> target in {U16, F32}
+  F32 -> target == F32
+```
+
+Two properties this guarantees, both from the user's constraints:
+- **No downconvert loss / HDR survives:** step 1's precision gate is widen-only;
+  step 2 falls back to native, never to a lossy default. A 10-bit PQ source
+  against `preferred=[RGB8]` returns native U16-PQ, not flattened RGB8.
+- **No bloat:** because it is *widen-only, first-acceptable*, it never picks a
+  wider candidate than the source needs unless the caller explicitly asked. To
+  stop upconvert bloat on the encode side, feed `available` = the target's
+  **fidelity envelope** (§3), so a 16-bit source → WebP sees only 8-bit
+  candidates and lands at 8-bit — no f32 buffer.
+
+### 5.3 The transcode path collapses
+
+`CodecSet::transcode` reduces to a single decode:
+
+```
+decode_preferring(input, encoder.fidelity_envelope())   # one decode
+   -> decoder negotiates its native desc against the envelope, source-aware
+carry Metadata::from(&info)  ->  encode
+```
+
+No double-decode, no membership pre-check. The decoder does the precision match
+because only it holds the exact source.
+
+---
+
+## 6. Trait & helper changes (grounded in the surveys)
+
+**Shared (`zencodec`):**
+- `negotiate_pixel_format(source, preferred, available)` — new source-aware
+  signature (deprecate the `(preferred, available)` one at `negotiate.rs:49`).
+  Body = §5.2, lifted from JXL. Add `can_produce_losslessly` as a public helper.
+- `best_encode_format(source, supported)` already takes `source`
+  (`negotiate.rs:94`) — make its ranking precision/bloat-aware (least-precision
+  covering candidate), not first-format-match.
+
+**Decoder side:**
+- `decoder(data, preferred)` (+ `push_/streaming_/animation_frame_`) keep their
+  signatures; contract doc updated to "closest-to-source, widen-only, native
+  fallback, never flatten." Each decoder calls the new helper with its native
+  descriptor. **Only PNG, JPEG, GIF, WebP, zenbitmaps change** (adopt the shared
+  helper); JXL/AVIF/HEIC are already correct.
+- `ImageInfo.source_descriptor: Option<PixelDescriptor>` — best-effort, populated
+  at probe per the Tier table (§1). Transparency only.
+- **Probe fidelity fixes surfaced by the survey** (separate, non-blocking):
+  PNG `cLLI`→`cLLi` casing; PNG gAMA/cHRM/sRGB → `SourceColor`; JXL float flag at
+  probe; JPEG color-model/subsampling; AVIF nclx-absent OBU fallback + diffuse_white.
+
+**Encoder side:**
+- Redefine `supported_descriptors()` = **fidelity envelope** (what the encoder
+  *preserves*), ordered by preference. WebP/GIF/JPEG drop their `*F32` (and JPEG
+  its 16-bit) from the fidelity list; those remain accept-and-convert conveniences
+  inside `encode()`. AVIF's ceiling is 10-bit (its 16-bit entries are convert).
+  JXL/PNG/farbfeld lists are already honest.
+- Contract: encode at the input's precision — never silently upconvert.
+
+**Rollout:** additive (deprecate, don't remove); testkit
+`check_precision_negotiation` feeds 8-bit and 16-bit fixtures and asserts the
+output descriptor matches the source (no flatten, no bloat) — catches the
+PNG-vs-JXL divergence and any regression.
+
+---
+
+## 7. Per-codec source references
+
+- **JPEG** `zenjpeg/zenjpeg/src/codec/decode.rs:185-207,353-370,1020-1064`,
+  `encode.rs:209-222,288-290,960-1014`, probe `decode.rs:309-320`→`info.rs:11-46`.
+- **PNG** `zenpng/src/codec.rs:45-71,2612-2645,2696-2746`; probe
+  `codec.rs:1830-1940`, tRNS `ancillary.rs:187-201`, cLLI bug `ancillary.rs:222`.
+- **WebP** `zenwebp/src/codec.rs:323-355,1500-1528,2136-2249,949-1039`; probe
+  `detect.rs`, float traps `tests/float_input_descriptors.rs`.
+- **GIF** `zengif/src/codec.rs:171-187,454-456,1058-1060,1225-1544`; probe walk
+  `detect.rs:173,267-360`, `cheap_probe=false` `codec.rs:234`.
+- **AVIF** `zenavif/src/codec.rs:245-308,1665-1693,2265-2322,2579-2649`; ravif
+  `ravif/ravif/src/av1encoder.rs:76-80,1111,1263-1313`.
+- **JXL** `zenjxl/src/decode.rs:391-475` (the reference algorithm),
+  `codec.rs:105-124,1714-1730,1930-2061`.
+- **HEIC** `heic/src/codec.rs:99-105,206,554-577,827,1681-1849`; decode-only.
+- **RAW/DNG** `zenraw/src/zencodec_impl.rs:253-254,416-466`,
+  `decode.rs:363-422,1002-1007`; decode-only, decoder-decides output.
+- **zenbitmaps** `bmp_codec.rs:31-36,325-375`, `pnm_codec.rs:46-54,177-201`,
+  `farbfeld_codec.rs:33-38,310-325`, `hdr_codec.rs:29,357-367`,
+  `tga_codec.rs:34-38,373-393`, `qoi_codec.rs:31-32,403-416`; all
+  `decoder()` ignore `preferred` (source-driven).

--- a/docs/pixel-descriptor-negotiation.md
+++ b/docs/pixel-descriptor-negotiation.md
@@ -280,3 +280,207 @@ PNG-vs-JXL divergence and any regression.
   `farbfeld_codec.rs:33-38,310-325`, `hdr_codec.rs:29,357-367`,
   `tga_codec.rs:34-38,373-393`, `qoi_codec.rs:31-32,403-416`; all
   `decoder()` ignore `preferred` (source-driven).
+
+---
+
+# PHASE 2 — convert paths, multi-page, and color management
+
+**Provenance:** 4 further surveys (zenpixels-convert; TIFF/PDF multi-page; the
+color-emit decision layer; moxcms), 2026-07-14. This section **revises §5–§6**:
+the "lift JXL's `choose_pixel_format` into a new shared helper" plan is superseded
+— a richer classifier already exists and should be *relocated*, not reinvented.
+
+## 8. Fidelity is a per-image PIPELINE, not a single descriptor pick
+
+A transcode is a chain, and end-to-end fidelity is the **composition** of three
+arrows (worst link dominates), each with its own per-image `DescriptorSupport`:
+
+```
+source ─[decode]→ decoded ─[convert / CMS]→ adapted ─[encode]→ output
+        arrow 1            arrow 2                    arrow 3
+                                              (+ color signaling: a parallel
+                                               metadata channel on arrow 3)
+```
+
+The middle arrow — **convert (`zenpixels-convert`)** — is a first-class fidelity
+actor the Phase-1 survey didn't examine. The negotiator's job is not "pick one
+descriptor" but "choose the path that minimizes total loss," per page.
+
+## 9. The classifier already exists — relocate, don't reinvent
+
+`zenpixels-convert` already contains a **provenance-aware, descriptor-only fidelity
+classifier** far richer than JXL's decode-only slice or zencodec's naive
+`negotiate_pixel_format`:
+
+- **`conversion_cost_with_provenance(from, to, prov) -> ConversionCost{effort, loss}`**
+  (`negotiate.rs:493`). **`loss == 0` IS the lossless predicate.**
+- **`LossBucket::from_model_loss`** (`pipeline/path.rs:41`): `Lossless ≤10 ·
+  NearLossless ≤50 · LowLoss ≤150 · Moderate ≤400 · High`.
+- Supporting: `PixelDescriptor::layout_compatible`, `descriptors_match`
+  (`output.rs:520`), `requires_cms`, `ConvertStep::Identity`.
+
+### The fidelity map (loss = 0 ⇒ lossless)
+
+| Conversion | Class | Condition |
+|---|---|---|
+| BGRA↔RGBA swizzle, add-alpha, Gray→RGB/RGBA replicate | **Lossless** | always |
+| drop-alpha | Lossy(50) | **Lossless iff alpha Opaque/Undefined** |
+| RGB→Gray (Y′ luma) | Lossy(500) | exact only if R==G==B |
+| precision widen U8→U16→F32 | **Lossless** | `target_bits ≥ origin_bits` |
+| precision narrow | Lossy | **Lossless iff provenance origin already fit** |
+| transfer sRGB↔Linear / gamma | **Lossless** (f32) | always |
+| transfer **PQ/HLG** | Lossy(300) | *blanket over-charge* — decode is actually lossless |
+| gamut map | Lossless | **iff `dst.contains(src)`** (widening); clip = Lossy(80–200) |
+| alpha premul/unpremul | NearLossless(5/10) | division rounding |
+| Oklab round-trip (f32) | **Lossless** | known primaries |
+| HDR tone-map | Lossy | irreversible; `hdr-experimental` only |
+
+The **provenance round-trip rule** is the important subtlety: narrowing F32→U8 is
+`Lossless` when the data *originated* as U8 (widened earlier in the chain). This is
+exactly what a decode→convert→encode pipeline needs to avoid double-counting.
+
+### Where it belongs
+
+The classifier reads **only descriptor fields** (`primaries, transfer,
+channel_type, layout, alpha, signal_range`) + a `Provenance` derived from the
+source — it never touches `ColorContext`, so it is **`no_std`-able**. Today it's
+trapped in the `std`/CMS convert crate, which zencodec (no_std) can't depend on.
+
+**Recommendation: move the classifier down into `zenpixels`** (its natural home —
+the fidelity relationship between two `PixelDescriptor`s is a `PixelDescriptor`
+concern), e.g. `zenpixels::fidelity::conversion_cost(from, to, prov)` or
+`PixelDescriptor::fidelity_to(target, prov)`. Then **one** classifier serves
+zencodec's decode/encode negotiation, every decoder, and zenpixels-convert's
+`best_match`. zencodec's naive `negotiate_pixel_format` becomes a thin call into it
+(or is deleted). This is a *move + small API*, not a from-scratch build.
+
+### Two-tier: descriptor classifier + CMS resolution (the ICC caveat)
+
+The classifier is **blind to custom-ICC-vs-custom-ICC**: two different ICC profiles
+sharing `(primaries, transfer)` score as identity/lossless, even when moxcms would
+gamut-clip between them (`color_profile_source()` is a `const fn` returning only a
+`PrimariesTransferPair` — it structurally cannot carry ICC bytes). So fidelity is
+two-tier:
+- **Tier 1 — descriptor classifier** (no_std, fast): exact for named/CICP
+  colorimetry — the common case.
+- **Tier 2 — CMS `ColorContext` check** (std, moxcms): required only when both
+  sides carry custom ICCs with matching descriptors. Resolve at the CMS boundary.
+
+## 10. `StorageFidelity` is still needed — the classifier can't derive it
+
+The per-image classifier (arrow-2 and the source↔candidate part of arrows 1/3)
+does **not** replace the static encode tag, because a codec's *internal*
+downconvert is invisible in the descriptor: WebP advertises `RGBF32` but stores
+8-bit. That is a codec-implementation fact, not a descriptor relationship.
+
+So the two-arrows split stands:
+- **Static, encode-side** — `StorageFidelity { Exact, Lossless, Downconverts }` on
+  each `SupportedDescriptor` in the encode list (candidate→codec-storage;
+  source-independent). Filters the candidate set to the fidelity envelope.
+- **Computed, both sides / all arrows** — the classifier returns the per-image
+  `DescriptorSupport` (source→candidate). This is the "native/lossless changes per
+  image" result; it must never be baked into a static list.
+
+Decode `supported_descriptors()` stays `&[PixelDescriptor]` (nativeness is
+source-relative → computed). Only the encode list gains the static tag.
+
+## 11. Multi-page (TIFF, PDF) — the pipeline runs PER PAGE
+
+- **Pages genuinely differ.** TIFF IFDs each independently declare
+  depth/channels/photometric/alpha/ICC (image-tiff does *not* inherit tags across
+  IFDs — `image.rs:180`); page 1 gray-8, page 2 RGB-16, page 3 CMYK, page 4 RGBA
+  are all valid. PDF pages differ in dims + source color spaces.
+- **But both decoders flatten.** TIFF keeps 8/16/f32 gray/RGB/RGBA, **collapses
+  CMYK/YCbCr/Lab/Palette → RGB(A)** (CMYK is absent from `TIFF_DECODE_DESCRIPTORS`).
+  PDF renders **every page to RGBA8** (hayro→vello_cpu). TIFF is at
+  `zenextras/zentiff` (fully wired decode+encode); PDF at `zenextras/zenpdf`
+  (decode-only, `Custom` format).
+- **`MultiPageDecoder` is vaporware** — zero code; only a sketch in
+  `docs/multi-image-design.md:368` (`page_info(index) -> ImageInfo`,
+  `decode_page(index, preferred, stop) -> DecodeOutput`, per-page `preferred`).
+- **The model gap:** `ImageInfo` is single-valued (one `source_color`, one
+  `has_alpha` = "primary image only", `info.rs:434`). Per-page descriptors have
+  nowhere to go and no enumeration API. `DecodeJob::with_start_frame_index` exists
+  (no-op default); PDF overrides it (page-select), **TIFF does not** (locked to
+  IFD0 through zencodec despite image-tiff's `seek_to_image` random access).
+- **CMYK→CMYK transcode is impossible today.** `PixelDescriptor` models CMYK
+  first-class (`ChannelLayout::Cmyk`, `CMYK8`), but neither decoder emits it — the
+  channels are RGB-ified before any encoder sees them, and probe never reports
+  CMYK. Preserving it needs (a) a CMYK-preserving decode mode via `preferred` (TIFF
+  ignores `preferred` today), and (b) per-page descriptor reporting.
+
+**Requirement:** implement the sketched `MultiPageDecoder` so the source-aware
+pipeline (decode→convert→encode, §8) runs per page with per-page `preferred`. The
+negotiator is already per-image; multi-page just iterates it with a per-page
+source descriptor.
+
+## 12. Color management — retag vs CMS, and a live corruption hazard
+
+Color splits cleanly into the two-arrows model, but **both halves are landed-yet-
+unwired for transcode**:
+
+- **Signaling retag (arrow-3 metadata) — LOSSLESS.** `resolve_color_emit`
+  (`color.rs:247`) decides ICC-vs-CICP emission; "orthogonal to which pixels are
+  written." Handles CMYK/gray terminals (keep ICC, suppress RGB CICP). Every policy
+  (Compatibility/Balanced/Compact/Verbatim/Custom) is a retag — **no policy
+  recolors** P3/PQ→sRGB. **Zero production callers today.**
+- **Pixel CMS (arrow-2) — Lossless or Lossy.** Gamut-widen = Lossless; gamut-clip,
+  TRC remap w/ quantization, HDR→SDR tone-map = Lossy. Lives in zenpixels-convert
+  (moxcms wired behind `cms-moxcms`). But `finalize_for_output*` (the lowering that
+  would consume a `ColorEmitPlan` and run source-driven CMS) has **zero production
+  callers**; only zenpipe's *explicit* ICC→ICC `IccTransform` node runs CMS. There
+  is **no decode-side `ConvertToSrgb`/`ColorIntent` knob** in zencodec at all.
+
+**Retag-vs-Lossy rule:** a transfer/primaries change is a **Native retag** iff the
+pixels already carry the target's transfer AND primaries (`descriptors_match` →
+byte copy) or you are only relabeling metadata. It is a **Lossy transform** when
+primaries narrow (gamut clip), a TRC is remapped with quantization, or an HDR
+transfer meets an SDR target (tone-map). Widening depth/gamut without clip is the
+only Lossless-transform middle ground. HDR→HDR (PQ→PQ, same primaries) = lossless
+retag.
+
+### ⚠ Live corruption hazard — HDR→SDR fails OPEN
+
+On a default (non-`hdr-experimental`) build, a PQ/HLG→sRGB `RowConverter` takes the
+no-tone-map arms and **hard-clips every highlight to 1.0 silently**
+(`convert.rs:549-566,1835-1844`); the refusal guard that would stop it is itself
+feature-gated. Runner-up: the gamut step is skipped when either primaries is
+`Unknown` (`convert.rs:664`), silently relabeling wide-gamut pixels as sRGB. Both
+violate "the user's pixels are sacred" for any transcode that crosses HDR→SDR or
+wide→narrow gamut.
+
+**Design rule for the negotiator:** an HDR→SDR or gamut-narrowing descriptor
+transition must route through an explicit (tone-map / gamut-map) convert step and
+be reported as `Lossy` — or the transcode must **refuse** (error), never silently
+clip. The negotiator's transfer/primaries gates (§5.2) are exactly this boundary;
+they must be enforced, not bypassed.
+
+## 13. Revised architecture & trait changes (supersedes §6)
+
+1. **Relocate the fidelity classifier** `conversion_cost`/`LossBucket`/component
+   fns from `zenpixels-convert` into **`zenpixels`** (no_std). One classifier for
+   decode negotiation, encode negotiation, decoders, and convert.
+2. **zencodec `negotiate_pixel_format(source, preferred, available)`** becomes a
+   thin wrapper over the relocated classifier (widen-only, native fallback, never
+   flatten — §5.2), returning `Negotiated { descriptor, fidelity: DescriptorSupport }`.
+   Delete the precision-blind version.
+3. **Encode `supported_descriptors() -> &[SupportedDescriptor]`** with the static
+   `StorageFidelity` tag (§10). Decode list unchanged. `From<PixelDescriptor>`
+   defaults to `Exact` for mechanical migration; codecs downgrade their
+   accept-convert entries.
+4. **`ImageInfo.source_descriptor: Option<PixelDescriptor>`** — best-effort
+   transparency (Phase-1 §1 tiers); authoritative source is the decoder-native
+   descriptor.
+5. **`MultiPageDecoder`** (the sketched trait) — per-page `page_info` +
+   `decode_page(index, preferred)`, so the pipeline runs per page. Wire TIFF's
+   `seek_to_image` page selector; add CMYK-preserving decode via `preferred`.
+6. **Color: wire the decision→mechanism path.** Call `resolve_color_emit` on the
+   transcode encode side (signaling), and route pixel color changes through the
+   convert stage's CMS with the Tier-2 `ColorContext` check for custom ICCs. Close
+   the HDR→SDR fail-open (§12) — tone-map or refuse, never silent-clip.
+7. **Two-tier fidelity** — descriptor classifier (no_std, Tier 1) + moxcms
+   `ColorContext` resolution (std, Tier 2) for custom-ICC pairs.
+
+**Rollout stays additive** where possible; the classifier relocation + encode
+`SupportedDescriptor` type change are the two breaking pieces (pre-0.1, allowed).
+The testkit conformance check (§6) extends to a per-page + HDR-refusal case.

--- a/docs/public-api/zencodec-testkit.txt
+++ b/docs/public-api/zencodec-testkit.txt
@@ -6,25 +6,26 @@
 # impls omitted; re-export duplicates annotated `[also: path]`.
 # DO NOT EDIT BY HAND — commit regenerated changes with the code.
 #
-# files: zencodec-testkit.txt 60 lines (supported surface) | zencodec-testkit.features.txt 0 added (features: none) | zencodec-testkit.internal.txt 0 lines (0 hidden + 0 excluded-feature)
+# files: zencodec-testkit.txt 63 lines (supported surface) | zencodec-testkit.features.txt 0 added (features: none) | zencodec-testkit.internal.txt 0 lines (0 hidden + 0 excluded-feature)
 
 ## summary
 #
 #   pub modules                                 2
-#   pub types (struct/enum/trait/alias)        16
+#   pub types (struct/enum/trait/alias)        18
+#   pub consts/statics                          2
 #   free functions                             10
 #   inherent methods                            6
 #   struct fields                               2
 #   enum variants                              10
-#   trait roster entries (type × trait)        28
-#   auto-trait-complete types                   9
+#   trait roster entries (type × trait)        32
+#   auto-trait-complete types                  10
 #   auto-trait exceptions                       3
 #
 # per-module pub lines:
-#   (root)                           29
-#   reference                        17
+#   (root)                           31
+#   reference                        19
 
-## items (43 lines)
+## items (45 lines)
 
 pub mod zencodec_testkit
 pub mod reference
@@ -53,11 +54,13 @@ pub Failure::detail: alloc::string::String
 pub struct ReferenceDecoderConfig [also: reference]
 pub struct ReferenceEncoderConfig [also: reference]
 pub fn reference::ReferenceEncoderConfig::new() -> Self
+pub struct ReferenceZcrDecoderConfig [also: reference]
 pub struct TestImage
 pub fn TestImage::as_slice(&self) -> zenpixels::buffer::PixelSlice<'_>
 pub fn TestImage::rgb8_gradient(u32, u32) -> Self
 pub fn TestImage::rgba8_gradient(u32, u32) -> Self
 pub fn TestImage::rgba8_gradient_seeded(u32, u32, u8) -> Self
+pub static ZCR_FORMAT: zencodec::format::ImageFormatDefinition [also: reference]
 pub fn assert_uses_codec_error_envelope<E, D>() where E: zencodec::traits::encoding::EncoderConfig<Error = whereat::at::At<zencodec::error::CodecError>>, <E as zencodec::traits::encoding::EncoderConfig>::Job: zencodec::traits::encoding::EncodeJob<Error = whereat::at::At<zencodec::error::CodecError>>, <<E as zencodec::traits::encoding::EncoderConfig>::Job as zencodec::traits::encoding::EncodeJob>::Enc: zencodec::traits::encoder::Encoder<Error = whereat::at::At<zencodec::error::CodecError>>, D: zencodec::traits::decoding::DecoderConfig<Error = whereat::at::At<zencodec::error::CodecError>>, for<'a> <D as zencodec::traits::decoding::DecoderConfig>::Job: zencodec::traits::decoding::DecodeJob<'a, Error = whereat::at::At<zencodec::error::CodecError>>, for<'a> <<D as zencodec::traits::decoding::DecoderConfig>::Job as zencodec::traits::decoding::DecodeJob<'a>>::Dec: zencodec::traits::decoder::Decode<Error = whereat::at::At<zencodec::error::CodecError>>
 pub fn check_all<E, D>(E, D) -> Conformance where E: zencodec::traits::encoding::EncoderConfig, D: zencodec::traits::decoding::DecoderConfig, <<E as zencodec::traits::encoding::EncoderConfig>::Job as zencodec::traits::encoding::EncodeJob>::Enc: zencodec::traits::encoder::Encoder<Error = <E as zencodec::traits::encoding::EncoderConfig>::Error>, <<E as zencodec::traits::encoding::EncoderConfig>::Job as zencodec::traits::encoding::EncodeJob>::AnimationFrameEnc: zencodec::traits::encoder::AnimationFrameEncoder
 pub fn check_animation_cross_path_equivalence<E, D>(E, D, &[TestImage]) -> Conformance where E: zencodec::traits::encoding::EncoderConfig, D: zencodec::traits::decoding::DecoderConfig, <<E as zencodec::traits::encoding::EncoderConfig>::Job as zencodec::traits::encoding::EncodeJob>::AnimationFrameEnc: zencodec::traits::encoder::AnimationFrameEncoder
@@ -70,7 +73,7 @@ pub fn check_orientation_roundtrip<E, D>(E, D, &TestImage) -> Conformance where 
 pub fn check_pixel_roundtrip<E, D>(E, D, &TestImage) -> Conformance where E: zencodec::traits::encoding::EncoderConfig, D: zencodec::traits::decoding::DecoderConfig, <<E as zencodec::traits::encoding::EncoderConfig>::Job as zencodec::traits::encoding::EncodeJob>::Enc: zencodec::traits::encoder::Encoder<Error = <E as zencodec::traits::encoding::EncoderConfig>::Error>
 pub type Conformance = core::result::Result<(), Failure>
 
-## trait impls (13 types)
+## trait impls (14 types)
 
 Failure: Clone, Debug, Display, Error
 reference::RefAnimDec: zencodec::traits::decoder::AnimationFrameDecoder
@@ -84,11 +87,12 @@ reference::RefError: Debug, Display, Error, From<enough::reason::StopReason>, Fr
 reference::RefStreamDec<'_>: zencodec::traits::decoder::StreamingDecode
 reference::ReferenceDecoderConfig: Clone, Debug, Default, zencodec::traits::decoding::DecoderConfig
 reference::ReferenceEncoderConfig: Clone, Debug, Default, zencodec::traits::encoding::EncoderConfig
+reference::ReferenceZcrDecoderConfig: Clone, Debug, Default, zencodec::traits::decoding::DecoderConfig
 whereat::at::At<zencodec::error::CodecError>: From<reference::RefError>
 
 ## auto traits
 
-9 types implement all of: Freeze, RefUnwindSafe, Send, Sync, Unpin, UnwindSafe
+10 types implement all of: Freeze, RefUnwindSafe, Send, Sync, Unpin, UnwindSafe
 reference::RefAnimDec: !RefUnwindSafe !UnwindSafe
 reference::RefError: !RefUnwindSafe !UnwindSafe
 reference::RefStreamDec<'a>: !RefUnwindSafe !UnwindSafe

--- a/docs/public-api/zencodec.features.txt
+++ b/docs/public-api/zencodec.features.txt
@@ -10,13 +10,16 @@
 ## summary
 #
 #   pub consts/statics                          1
+#   inherent methods                            1
 #   trait roster entries (type × trait)         2
 #
 # per-module pub lines:
 #   (root)                            1
+#   estimate                          1
 
-## items (1 lines)
+## items (2 lines)
 
+pub fn estimate::ComputeEnvironment::host() -> Self
 pub const fn CodecIoKind::kind(&self) -> core::option::Option<core::io::error::ErrorKind>
 
 ## trait impls (1 types)

--- a/docs/public-api/zencodec.txt
+++ b/docs/public-api/zencodec.txt
@@ -6,7 +6,7 @@
 # impls omitted; re-export duplicates annotated `[also: path]`.
 # DO NOT EDIT BY HAND — commit regenerated changes with the code.
 #
-# files: zencodec.txt 1481 lines (supported surface) | zencodec.features.txt 2 added (features: std) | zencodec.internal.txt 89 lines (89 hidden + 0 excluded-feature)
+# files: zencodec.txt 1490 lines (supported surface) | zencodec.features.txt 3 added (features: std) | zencodec.internal.txt 89 lines (89 hidden + 0 excluded-feature)
 
 ## summary
 #
@@ -14,7 +14,7 @@
 #   pub types (struct/enum/trait/alias)       169
 #   pub consts/statics                        172
 #   free functions                             42
-#   inherent methods                          653
+#   inherent methods                          662
 #   struct fields                             196
 #   enum variants                             185
 #   re-exports                                 12
@@ -24,17 +24,17 @@
 #   auto-trait exceptions                       8
 #
 # per-module pub lines:
-#   (root)                          727
+#   (root)                          731
 #   decode                          168
-#   encode                          117
-#   estimate                         47
+#   encode                          119
+#   estimate                         48
 #   exif                             65
 #   gainmap                         126
 #   helpers                          13
 #   icc                               1
-#   prelude                         174
+#   prelude                         176
 
-## items (1386 lines)
+## items (1395 lines)
 
 pub mod zencodec
 pub use At
@@ -417,6 +417,7 @@ pub fn encode::DynAnimationFrameEncoder::finish(alloc::boxed::Box<Self>, core::o
 pub fn encode::DynAnimationFrameEncoder::into_any(alloc::boxed::Box<Self>) -> alloc::boxed::Box<dyn core::any::Any>
 pub fn encode::DynAnimationFrameEncoder::push_frame(&mut self, zenpixels::buffer::PixelSlice<'_>, u32, core::option::Option<&dyn enough::Stop>) -> core::result::Result<(), encode::BoxedError>
 pub trait encode::DynEncodeJob [also: prelude]
+pub fn encode::DynEncodeJob::encode(alloc::boxed::Box<Self>, zenpixels::buffer::PixelSlice<'_>) -> core::result::Result<encode::EncodeOutput, encode::BoxedError>
 pub fn encode::DynEncodeJob::extensions(&self) -> core::option::Option<&dyn core::any::Any>
 pub fn encode::DynEncodeJob::extensions_mut(&mut self) -> core::option::Option<&mut dyn core::any::Any>
 pub fn encode::DynEncodeJob::into_animation_frame_encoder(alloc::boxed::Box<Self>) -> core::result::Result<alloc::boxed::Box<dyn encode::DynAnimationFrameEncoder>, encode::BoxedError>
@@ -449,6 +450,7 @@ pub type encode::EncodeJob::Error: core::error::Error + core::marker::Send + cor
 pub fn encode::EncodeJob::animation_frame_encoder(self) -> core::result::Result<Self::AnimationFrameEnc, Self::Error>
 pub fn encode::EncodeJob::dyn_animation_frame_encoder(self) -> core::result::Result<alloc::boxed::Box<dyn encode::DynAnimationFrameEncoder>, encode::BoxedError> where Self::AnimationFrameEnc: encode::AnimationFrameEncoder + core::marker::Send
 pub fn encode::EncodeJob::dyn_encoder(self) -> core::result::Result<alloc::boxed::Box<dyn encode::DynEncoder>, encode::BoxedError> where Self::Enc: encode::Encoder + core::marker::Send
+pub fn encode::EncodeJob::encode(self, zenpixels::buffer::PixelSlice<'_>) -> core::result::Result<encode::EncodeOutput, Self::Error> where Self::Enc: encode::Encoder<Error = Self::Error>
 pub fn encode::EncodeJob::encoder(self) -> core::result::Result<Self::Enc, Self::Error>
 pub fn encode::EncodeJob::extensions(&self) -> core::option::Option<&dyn core::any::Any>
 pub fn encode::EncodeJob::extensions_mut(&mut self) -> core::option::Option<&mut dyn core::any::Any>
@@ -503,6 +505,7 @@ pub estimate::SimdTier::X86V3
 pub estimate::SimdTier::X86V4
 #[non_exhaustive] pub struct estimate::ComputeEnvironment
 pub fn estimate::ComputeEnvironment::available_ram_bytes(&self) -> core::option::Option<u64>
+pub fn estimate::ComputeEnvironment::conservative() -> Self
 pub fn estimate::ComputeEnvironment::cores(&self) -> usize
 pub fn estimate::ComputeEnvironment::new() -> Self
 pub fn estimate::ComputeEnvironment::simd_tier(&self) -> core::option::Option<estimate::SimdTier>
@@ -783,6 +786,7 @@ pub fn prelude::DynDecoderConfig::dyn_job(&self) -> alloc::boxed::Box<(dyn decod
 pub fn prelude::DynDecoderConfig::estimate_decode_resources(&self, &estimate::ImageCharacteristics, &estimate::ComputeEnvironment) -> estimate::ResourceEstimate
 pub fn prelude::DynDecoderConfig::formats(&self) -> &'static [ImageFormat]
 pub fn prelude::DynDecoderConfig::supported_descriptors(&self) -> &'static [zenpixels::descriptor::PixelDescriptor]
+pub fn prelude::DynEncodeJob::encode(alloc::boxed::Box<Self>, zenpixels::buffer::PixelSlice<'_>) -> core::result::Result<encode::EncodeOutput, encode::BoxedError>
 pub fn prelude::DynEncodeJob::extensions(&self) -> core::option::Option<&dyn core::any::Any>
 pub fn prelude::DynEncodeJob::extensions_mut(&mut self) -> core::option::Option<&mut dyn core::any::Any>
 pub fn prelude::DynEncodeJob::into_animation_frame_encoder(alloc::boxed::Box<Self>) -> core::result::Result<alloc::boxed::Box<dyn encode::DynAnimationFrameEncoder>, encode::BoxedError>
@@ -814,6 +818,7 @@ pub type prelude::EncodeJob::Error: core::error::Error + core::marker::Send + co
 pub fn prelude::EncodeJob::animation_frame_encoder(self) -> core::result::Result<Self::AnimationFrameEnc, Self::Error>
 pub fn prelude::EncodeJob::dyn_animation_frame_encoder(self) -> core::result::Result<alloc::boxed::Box<dyn encode::DynAnimationFrameEncoder>, encode::BoxedError> where Self::AnimationFrameEnc: encode::AnimationFrameEncoder + core::marker::Send
 pub fn prelude::EncodeJob::dyn_encoder(self) -> core::result::Result<alloc::boxed::Box<dyn encode::DynEncoder>, encode::BoxedError> where Self::Enc: encode::Encoder + core::marker::Send
+pub fn prelude::EncodeJob::encode(self, zenpixels::buffer::PixelSlice<'_>) -> core::result::Result<encode::EncodeOutput, Self::Error> where Self::Enc: encode::Encoder<Error = Self::Error>
 pub fn prelude::EncodeJob::encoder(self) -> core::result::Result<Self::Enc, Self::Error>
 pub fn prelude::EncodeJob::extensions(&self) -> core::option::Option<&dyn core::any::Any>
 pub fn prelude::EncodeJob::extensions_mut(&mut self) -> core::option::Option<&mut dyn core::any::Any>
@@ -1109,6 +1114,10 @@ pub fn CodecSet::encode_job(&self, ImageFormat) -> core::result::Result<alloc::b
 pub fn CodecSet::encode_job_with(&self, ImageFormat, encode::Fidelity) -> core::result::Result<alloc::boxed::Box<dyn encode::DynEncodeJob>, CodecSetError>
 pub fn CodecSet::encode_with(&self, ImageFormat, encode::Fidelity, zenpixels::buffer::PixelSlice<'_>) -> core::result::Result<encode::EncodeOutput, CodecSetError>
 pub fn CodecSet::encoder_for(&self, ImageFormat) -> core::option::Option<&dyn encode::DynEncoderConfig>
+pub fn CodecSet::estimate_decode(&self, ImageFormat, &estimate::ImageCharacteristics, &estimate::ComputeEnvironment) -> core::result::Result<estimate::ResourceEstimate, CodecSetError>
+pub fn CodecSet::estimate_decode_of(&self, &[u8], &estimate::ComputeEnvironment) -> core::result::Result<estimate::ResourceEstimate, CodecSetError>
+pub fn CodecSet::estimate_encode(&self, ImageFormat, &estimate::ImageCharacteristics, &estimate::ComputeEnvironment) -> core::result::Result<estimate::ResourceEstimate, CodecSetError>
+pub fn CodecSet::estimate_encode_of(&self, ImageFormat, zenpixels::buffer::PixelSlice<'_>, &estimate::ComputeEnvironment) -> core::result::Result<estimate::ResourceEstimate, CodecSetError>
 pub fn CodecSet::new() -> Self
 pub fn CodecSet::probe<'a>(&'a self, &'a [u8]) -> core::result::Result<ImageInfo, CodecSetError>
 pub fn CodecSet::push_decode<'a>(&'a self, &'a [u8], &mut dyn decode::DecodeRowSink, &[zenpixels::descriptor::PixelDescriptor]) -> core::result::Result<decode::OutputInfo, CodecSetError>

--- a/docs/public-api/zencodec.txt
+++ b/docs/public-api/zencodec.txt
@@ -6,7 +6,7 @@
 # impls omitted; re-export duplicates annotated `[also: path]`.
 # DO NOT EDIT BY HAND — commit regenerated changes with the code.
 #
-# files: zencodec.txt 1490 lines (supported surface) | zencodec.features.txt 3 added (features: std) | zencodec.internal.txt 89 lines (89 hidden + 0 excluded-feature)
+# files: zencodec.txt 1491 lines (supported surface) | zencodec.features.txt 3 added (features: std) | zencodec.internal.txt 89 lines (89 hidden + 0 excluded-feature)
 
 ## summary
 #
@@ -14,7 +14,7 @@
 #   pub types (struct/enum/trait/alias)       169
 #   pub consts/statics                        172
 #   free functions                             42
-#   inherent methods                          662
+#   inherent methods                          663
 #   struct fields                             196
 #   enum variants                             185
 #   re-exports                                 12
@@ -24,7 +24,7 @@
 #   auto-trait exceptions                       8
 #
 # per-module pub lines:
-#   (root)                          731
+#   (root)                          732
 #   decode                          168
 #   encode                          119
 #   estimate                         48
@@ -34,7 +34,7 @@
 #   icc                               1
 #   prelude                         176
 
-## items (1395 lines)
+## items (1396 lines)
 
 pub mod zencodec
 pub use At
@@ -1122,6 +1122,7 @@ pub fn CodecSet::new() -> Self
 pub fn CodecSet::probe<'a>(&'a self, &'a [u8]) -> core::result::Result<ImageInfo, CodecSetError>
 pub fn CodecSet::push_decode<'a>(&'a self, &'a [u8], &mut dyn decode::DecodeRowSink, &[zenpixels::descriptor::PixelDescriptor]) -> core::result::Result<decode::OutputInfo, CodecSetError>
 pub fn CodecSet::streaming_decoder<'a>(&'a self, &'a [u8], &[zenpixels::descriptor::PixelDescriptor]) -> core::result::Result<alloc::boxed::Box<(dyn decode::DynStreamingDecoder + 'a)>, CodecSetError>
+pub fn CodecSet::transcode(&self, &[u8], ImageFormat, encode::Fidelity, MetadataPolicy, ColorEmitPolicy) -> core::result::Result<encode::EncodeOutput, CodecSetError>
 pub fn CodecSet::with_decode_policy(self, decode::DecodePolicy) -> Self
 pub fn CodecSet::with_decoder(self, impl decode::DecoderConfig + 'static) -> Self
 pub fn CodecSet::with_encode_policy(self, encode::EncodePolicy) -> Self

--- a/docs/public-api/zencodec.txt
+++ b/docs/public-api/zencodec.txt
@@ -6,34 +6,35 @@
 # impls omitted; re-export duplicates annotated `[also: path]`.
 # DO NOT EDIT BY HAND — commit regenerated changes with the code.
 #
-# files: zencodec.txt 1283 lines (supported surface) | zencodec.features.txt 2 added (features: std) | zencodec.internal.txt 89 lines (89 hidden + 0 excluded-feature)
+# files: zencodec.txt 1481 lines (supported surface) | zencodec.features.txt 2 added (features: std) | zencodec.internal.txt 89 lines (89 hidden + 0 excluded-feature)
 
 ## summary
 #
-#   pub modules                                 8
-#   pub types (struct/enum/trait/alias)       132
+#   pub modules                                 9
+#   pub types (struct/enum/trait/alias)       169
 #   pub consts/statics                        172
-#   free functions                             39
-#   inherent methods                          484
+#   free functions                             42
+#   inherent methods                          653
 #   struct fields                             196
-#   enum variants                             181
+#   enum variants                             185
 #   re-exports                                 12
-#   trait roster entries (type × trait)       379
-#   conditional trait impls (verbatim)          2
+#   trait roster entries (type × trait)       386
+#   conditional trait impls (verbatim)          4
 #   auto-trait-complete types                  67
-#   auto-trait exceptions                       6
+#   auto-trait exceptions                       8
 #
 # per-module pub lines:
-#   (root)                          690
-#   decode                          166
-#   encode                          116
+#   (root)                          727
+#   decode                          168
+#   encode                          117
 #   estimate                         47
 #   exif                             65
 #   gainmap                         126
 #   helpers                          13
 #   icc                               1
+#   prelude                         174
 
-## items (1194 lines)
+## items (1386 lines)
 
 pub mod zencodec
 pub use At
@@ -204,7 +205,7 @@ pub fn SourceColor::with_color_authority(self, zenpixels::color::ColorAuthority)
 pub fn SourceColor::with_content_light_level(self, zenpixels::hdr::ContentLightLevel) -> Self
 pub fn SourceColor::with_icc_profile(self, impl core::convert::Into<alloc::sync::Arc<[u8]>>) -> Self
 pub fn SourceColor::with_mastering_display(self, zenpixels::hdr::MasteringDisplay) -> Self
-pub trait decode::AnimationFrameDecoder: core::marker::Sized
+pub trait decode::AnimationFrameDecoder: core::marker::Sized [also: prelude]
 pub type decode::AnimationFrameDecoder::Error: core::error::Error + core::marker::Send + core::marker::Sync + 'static
 pub fn decode::AnimationFrameDecoder::frame_count(&self) -> core::option::Option<u32>
 pub fn decode::AnimationFrameDecoder::info(&self) -> &ImageInfo
@@ -213,10 +214,10 @@ pub fn decode::AnimationFrameDecoder::render_next_frame(&mut self, core::option:
 pub fn decode::AnimationFrameDecoder::render_next_frame_owned(&mut self, core::option::Option<&dyn enough::Stop>) -> core::result::Result<core::option::Option<OwnedAnimationFrame>, Self::Error>
 pub fn decode::AnimationFrameDecoder::render_next_frame_to_sink(&mut self, core::option::Option<&dyn enough::Stop>, &mut dyn decode::DecodeRowSink) -> core::result::Result<core::option::Option<decode::OutputInfo>, Self::Error>
 pub fn decode::AnimationFrameDecoder::wrap_sink_error(decode::SinkError) -> Self::Error
-pub trait decode::Decode: core::marker::Sized
+pub trait decode::Decode: core::marker::Sized [also: prelude]
 pub type decode::Decode::Error: core::error::Error + core::marker::Send + core::marker::Sync + 'static
 pub fn decode::Decode::decode(self) -> core::result::Result<decode::DecodeOutput, Self::Error>
-pub trait decode::DecodeJob<'a>: core::marker::Sized
+pub trait decode::DecodeJob<'a>: core::marker::Sized [also: prelude]
 pub type decode::DecodeJob::AnimationFrameDec: decode::AnimationFrameDecoder<Error = Self::Error> + core::marker::Send + 'static
 pub type decode::DecodeJob::Dec: decode::Decode<Error = Self::Error>
 pub type decode::DecodeJob::Error: core::error::Error + core::marker::Send + core::marker::Sync + 'static
@@ -245,15 +246,17 @@ pub trait decode::DecodeRowSink
 pub fn decode::DecodeRowSink::begin(&mut self, u32, u32, zenpixels::descriptor::PixelDescriptor) -> core::result::Result<(), decode::SinkError>
 pub fn decode::DecodeRowSink::finish(&mut self) -> core::result::Result<(), decode::SinkError>
 pub fn decode::DecodeRowSink::provide_next_buffer(&mut self, u32, u32, u32, zenpixels::descriptor::PixelDescriptor) -> core::result::Result<zenpixels::buffer::PixelSliceMut<'_>, decode::SinkError>
-pub trait decode::DecoderConfig: core::clone::Clone + core::marker::Send + core::marker::Sync
+pub trait decode::DecoderConfig: core::clone::Clone + core::marker::Send + core::marker::Sync [also: prelude]
 pub type decode::DecoderConfig::Error: core::error::Error + core::marker::Send + core::marker::Sync + 'static
 pub type decode::DecoderConfig::Job<'a>: decode::DecodeJob<'a, Error = Self::Error> + 'static
 pub fn decode::DecoderConfig::capabilities() -> &'static decode::DecodeCapabilities
+pub fn decode::DecoderConfig::decode(self, &[u8]) -> core::result::Result<decode::DecodeOutput, Self::Error> where Self: core::marker::Sized
 pub fn decode::DecoderConfig::estimate_decode_resources(&self, &estimate::ImageCharacteristics, &estimate::ComputeEnvironment) -> estimate::ResourceEstimate
 pub fn decode::DecoderConfig::formats() -> &'static [ImageFormat]
 pub fn decode::DecoderConfig::job<'a>(self) -> Self::Job
+pub fn decode::DecoderConfig::probe(&self, &[u8]) -> core::result::Result<ImageInfo, Self::Error> where Self: core::marker::Sized
 pub fn decode::DecoderConfig::supported_descriptors() -> &'static [zenpixels::descriptor::PixelDescriptor]
-pub trait decode::DynAnimationFrameDecoder: core::marker::Send
+pub trait decode::DynAnimationFrameDecoder: core::marker::Send [also: prelude]
 pub fn decode::DynAnimationFrameDecoder::as_any(&self) -> &dyn core::any::Any
 pub fn decode::DynAnimationFrameDecoder::as_any_mut(&mut self) -> &mut dyn core::any::Any
 pub fn decode::DynAnimationFrameDecoder::frame_count(&self) -> core::option::Option<u32>
@@ -262,7 +265,7 @@ pub fn decode::DynAnimationFrameDecoder::into_any(alloc::boxed::Box<Self>) -> al
 pub fn decode::DynAnimationFrameDecoder::loop_count(&self) -> core::option::Option<u32>
 pub fn decode::DynAnimationFrameDecoder::render_next_frame_owned(&mut self, core::option::Option<&dyn enough::Stop>) -> core::result::Result<core::option::Option<OwnedAnimationFrame>, encode::BoxedError>
 pub fn decode::DynAnimationFrameDecoder::render_next_frame_to_sink(&mut self, core::option::Option<&dyn enough::Stop>, &mut dyn decode::DecodeRowSink) -> core::result::Result<core::option::Option<decode::OutputInfo>, encode::BoxedError>
-pub trait decode::DynDecodeJob<'a>
+pub trait decode::DynDecodeJob<'a> [also: prelude]
 pub fn decode::DynDecodeJob::extensions(&self) -> core::option::Option<&dyn core::any::Any>
 pub fn decode::DynDecodeJob::extensions_mut(&mut self) -> core::option::Option<&mut dyn core::any::Any>
 pub fn decode::DynDecodeJob::into_animation_frame_decoder(alloc::boxed::Box<Self>, alloc::borrow::Cow<'a, [u8]>, &[zenpixels::descriptor::PixelDescriptor]) -> core::result::Result<alloc::boxed::Box<dyn decode::DynAnimationFrameDecoder>, encode::BoxedError>
@@ -280,21 +283,21 @@ pub fn decode::DynDecodeJob::set_orientation(&mut self, OrientationHint)
 pub fn decode::DynDecodeJob::set_policy(&mut self, decode::DecodePolicy)
 pub fn decode::DynDecodeJob::set_start_frame_index(&mut self, u32)
 pub fn decode::DynDecodeJob::set_stop(&mut self, almost_enough::stop_token::StopToken)
-pub trait decode::DynDecoder
+pub trait decode::DynDecoder [also: prelude]
 pub fn decode::DynDecoder::decode(alloc::boxed::Box<Self>) -> core::result::Result<decode::DecodeOutput, encode::BoxedError>
-pub trait decode::DynDecoderConfig: core::marker::Send + core::marker::Sync
+pub trait decode::DynDecoderConfig: core::marker::Send + core::marker::Sync [also: prelude]
 pub fn decode::DynDecoderConfig::as_any(&self) -> &dyn core::any::Any
 pub fn decode::DynDecoderConfig::capabilities(&self) -> &'static decode::DecodeCapabilities
 pub fn decode::DynDecoderConfig::dyn_job(&self) -> alloc::boxed::Box<(dyn decode::DynDecodeJob<'_> + '_)>
 pub fn decode::DynDecoderConfig::estimate_decode_resources(&self, &estimate::ImageCharacteristics, &estimate::ComputeEnvironment) -> estimate::ResourceEstimate
 pub fn decode::DynDecoderConfig::formats(&self) -> &'static [ImageFormat]
 pub fn decode::DynDecoderConfig::supported_descriptors(&self) -> &'static [zenpixels::descriptor::PixelDescriptor]
-pub trait decode::DynStreamingDecoder: core::marker::Send
+pub trait decode::DynStreamingDecoder: core::marker::Send [also: prelude]
 pub fn decode::DynStreamingDecoder::info(&self) -> &ImageInfo
 pub fn decode::DynStreamingDecoder::next_batch(&mut self) -> core::result::Result<core::option::Option<(u32, zenpixels::buffer::PixelSlice<'_>)>, encode::BoxedError>
 pub fn decode::SourceEncodingDetails::is_lossless(&self) -> bool
 pub fn decode::SourceEncodingDetails::source_generic_quality(&self) -> core::option::Option<f32>
-pub trait decode::StreamingDecode
+pub trait decode::StreamingDecode [also: prelude]
 pub type decode::StreamingDecode::Error: core::error::Error + core::marker::Send + core::marker::Sync + 'static
 pub fn decode::StreamingDecode::info(&self) -> &ImageInfo
 pub fn decode::StreamingDecode::next_batch(&mut self) -> core::result::Result<core::option::Option<(u32, zenpixels::buffer::PixelSlice<'_>)>, Self::Error>
@@ -398,22 +401,22 @@ pub const fn encode::EncodePolicy::with_color(self, ColorEmitPolicy) -> Self
 pub const fn encode::EncodePolicy::with_embed_exif(self, bool) -> Self
 pub const fn encode::EncodePolicy::with_embed_icc(self, bool) -> Self
 pub const fn encode::EncodePolicy::with_embed_xmp(self, bool) -> Self
-pub trait encode::AnimationFrameEncoder: core::marker::Sized
+pub trait encode::AnimationFrameEncoder: core::marker::Sized [also: prelude]
 pub type encode::AnimationFrameEncoder::Error: core::error::Error + core::marker::Send + core::marker::Sync + 'static
 pub fn encode::AnimationFrameEncoder::finish(self, core::option::Option<&dyn enough::Stop>) -> core::result::Result<encode::EncodeOutput, Self::Error>
 pub fn encode::AnimationFrameEncoder::push_frame(&mut self, zenpixels::buffer::PixelSlice<'_>, u32, core::option::Option<&dyn enough::Stop>) -> core::result::Result<(), Self::Error>
 pub fn encode::AnimationFrameEncoder::reject(UnsupportedOperation) -> Self::Error
-pub type ()::Error = UnsupportedOperation
-pub fn ()::finish(self, core::option::Option<&dyn enough::Stop>) -> core::result::Result<encode::EncodeOutput, Self::Error>
-pub fn ()::push_frame(&mut self, zenpixels::buffer::PixelSlice<'_>, u32, core::option::Option<&dyn enough::Stop>) -> core::result::Result<(), Self::Error>
-pub fn ()::reject(UnsupportedOperation) -> Self::Error
-pub trait encode::DynAnimationFrameEncoder: core::marker::Send
+pub type ()::Error = UnsupportedOperation [also: (root)]
+pub fn ()::finish(self, core::option::Option<&dyn enough::Stop>) -> core::result::Result<encode::EncodeOutput, Self::Error> [also: (root)]
+pub fn ()::push_frame(&mut self, zenpixels::buffer::PixelSlice<'_>, u32, core::option::Option<&dyn enough::Stop>) -> core::result::Result<(), Self::Error> [also: (root)]
+pub fn ()::reject(UnsupportedOperation) -> Self::Error [also: (root)]
+pub trait encode::DynAnimationFrameEncoder: core::marker::Send [also: prelude]
 pub fn encode::DynAnimationFrameEncoder::as_any(&self) -> &dyn core::any::Any
 pub fn encode::DynAnimationFrameEncoder::as_any_mut(&mut self) -> &mut dyn core::any::Any
 pub fn encode::DynAnimationFrameEncoder::finish(alloc::boxed::Box<Self>, core::option::Option<&dyn enough::Stop>) -> core::result::Result<encode::EncodeOutput, encode::BoxedError>
 pub fn encode::DynAnimationFrameEncoder::into_any(alloc::boxed::Box<Self>) -> alloc::boxed::Box<dyn core::any::Any>
 pub fn encode::DynAnimationFrameEncoder::push_frame(&mut self, zenpixels::buffer::PixelSlice<'_>, u32, core::option::Option<&dyn enough::Stop>) -> core::result::Result<(), encode::BoxedError>
-pub trait encode::DynEncodeJob
+pub trait encode::DynEncodeJob [also: prelude]
 pub fn encode::DynEncodeJob::extensions(&self) -> core::option::Option<&dyn core::any::Any>
 pub fn encode::DynEncodeJob::extensions_mut(&mut self) -> core::option::Option<&mut dyn core::any::Any>
 pub fn encode::DynEncodeJob::into_animation_frame_encoder(alloc::boxed::Box<Self>) -> core::result::Result<alloc::boxed::Box<dyn encode::DynAnimationFrameEncoder>, encode::BoxedError>
@@ -425,21 +428,21 @@ pub fn encode::DynEncodeJob::set_metadata(&mut self, Metadata)
 pub fn encode::DynEncodeJob::set_metadata_policy(&mut self, Metadata, MetadataPolicy)
 pub fn encode::DynEncodeJob::set_policy(&mut self, encode::EncodePolicy)
 pub fn encode::DynEncodeJob::set_stop(&mut self, almost_enough::stop_token::StopToken)
-pub trait encode::DynEncoder: core::marker::Send
+pub trait encode::DynEncoder: core::marker::Send [also: prelude]
 pub fn encode::DynEncoder::encode(alloc::boxed::Box<Self>, zenpixels::buffer::PixelSlice<'_>) -> core::result::Result<encode::EncodeOutput, encode::BoxedError>
 pub fn encode::DynEncoder::encode_from(alloc::boxed::Box<Self>, &mut dyn core::ops::function::FnMut(u32, zenpixels::buffer::PixelSliceMut<'_>) -> usize) -> core::result::Result<encode::EncodeOutput, encode::BoxedError>
 pub fn encode::DynEncoder::encode_srgba8(alloc::boxed::Box<Self>, &mut [u8], bool, u32, u32, u32) -> core::result::Result<encode::EncodeOutput, encode::BoxedError>
 pub fn encode::DynEncoder::finish(alloc::boxed::Box<Self>) -> core::result::Result<encode::EncodeOutput, encode::BoxedError>
 pub fn encode::DynEncoder::preferred_strip_height(&self) -> u32
 pub fn encode::DynEncoder::push_rows(&mut self, zenpixels::buffer::PixelSlice<'_>) -> core::result::Result<(), encode::BoxedError>
-pub trait encode::DynEncoderConfig: core::marker::Send + core::marker::Sync
+pub trait encode::DynEncoderConfig: core::marker::Send + core::marker::Sync [also: prelude]
 pub fn encode::DynEncoderConfig::as_any(&self) -> &dyn core::any::Any
 pub fn encode::DynEncoderConfig::capabilities(&self) -> &'static encode::EncodeCapabilities
 pub fn encode::DynEncoderConfig::dyn_job(&self) -> alloc::boxed::Box<(dyn encode::DynEncodeJob + 'static)>
 pub fn encode::DynEncoderConfig::estimate_encode_resources(&self, &estimate::ImageCharacteristics, &estimate::ComputeEnvironment) -> estimate::ResourceEstimate
 pub fn encode::DynEncoderConfig::format(&self) -> ImageFormat
 pub fn encode::DynEncoderConfig::supported_descriptors(&self) -> &'static [zenpixels::descriptor::PixelDescriptor]
-pub trait encode::EncodeJob: core::marker::Sized
+pub trait encode::EncodeJob: core::marker::Sized [also: prelude]
 pub type encode::EncodeJob::AnimationFrameEnc: core::marker::Sized + core::marker::Send + 'static
 pub type encode::EncodeJob::Enc: core::marker::Sized + 'static
 pub type encode::EncodeJob::Error: core::error::Error + core::marker::Send + core::marker::Sync + 'static
@@ -458,7 +461,7 @@ pub fn encode::EncodeJob::with_metadata(self, Metadata) -> Self
 pub fn encode::EncodeJob::with_metadata_policy(self, Metadata, MetadataPolicy) -> Self
 pub fn encode::EncodeJob::with_policy(self, encode::EncodePolicy) -> Self
 pub fn encode::EncodeJob::with_stop(self, almost_enough::stop_token::StopToken) -> Self
-pub trait encode::Encoder: core::marker::Sized
+pub trait encode::Encoder: core::marker::Sized [also: prelude]
 pub type encode::Encoder::Error: core::error::Error + core::marker::Send + core::marker::Sync + 'static
 pub fn encode::Encoder::encode(self, zenpixels::buffer::PixelSlice<'_>) -> core::result::Result<encode::EncodeOutput, Self::Error>
 pub fn encode::Encoder::encode_from(self, &mut dyn core::ops::function::FnMut(u32, zenpixels::buffer::PixelSliceMut<'_>) -> usize) -> core::result::Result<encode::EncodeOutput, Self::Error>
@@ -467,11 +470,12 @@ pub fn encode::Encoder::finish(self) -> core::result::Result<encode::EncodeOutpu
 pub fn encode::Encoder::preferred_strip_height(&self) -> u32
 pub fn encode::Encoder::push_rows(&mut self, zenpixels::buffer::PixelSlice<'_>) -> core::result::Result<(), Self::Error>
 pub fn encode::Encoder::reject(UnsupportedOperation) -> Self::Error
-pub trait encode::EncoderConfig: core::clone::Clone + core::marker::Send + core::marker::Sync
+pub trait encode::EncoderConfig: core::clone::Clone + core::marker::Send + core::marker::Sync [also: prelude]
 pub type encode::EncoderConfig::Error: core::error::Error + core::marker::Send + core::marker::Sync + 'static
 pub type encode::EncoderConfig::Job: encode::EncodeJob<Error = Self::Error>
 pub fn encode::EncoderConfig::alpha_quality(&self) -> core::option::Option<f32>
 pub fn encode::EncoderConfig::capabilities() -> &'static encode::EncodeCapabilities
+pub fn encode::EncoderConfig::encode(self, zenpixels::buffer::PixelSlice<'_>) -> core::result::Result<encode::EncodeOutput, Self::Error> where Self: core::marker::Sized, <Self::Job as encode::EncodeJob>::Enc: encode::Encoder<Error = Self::Error>
 pub fn encode::EncoderConfig::estimate_encode_resources(&self, &estimate::ImageCharacteristics, &estimate::ComputeEnvironment) -> estimate::ResourceEstimate
 pub fn encode::EncoderConfig::format() -> ImageFormat
 pub fn encode::EncoderConfig::generic_effort(&self) -> core::option::Option<i32>
@@ -694,6 +698,163 @@ pub fn helpers::identify_well_known_icc(&[u8], helpers::IccMatchTolerance) -> co
 pub fn helpers::parse_exif_orientation(&[u8]) -> core::option::Option<zenpixels::orientation::Orientation>
 pub fn helpers::set_exif_orientation(&[u8], zenpixels::orientation::Orientation) -> core::option::Option<alloc::vec::Vec<u8>>
 pub mod icc
+pub mod prelude
+pub type prelude::AnimationFrameDecoder::Error: core::error::Error + core::marker::Send + core::marker::Sync + 'static
+pub fn prelude::AnimationFrameDecoder::frame_count(&self) -> core::option::Option<u32>
+pub fn prelude::AnimationFrameDecoder::info(&self) -> &ImageInfo
+pub fn prelude::AnimationFrameDecoder::loop_count(&self) -> core::option::Option<u32>
+pub fn prelude::AnimationFrameDecoder::render_next_frame(&mut self, core::option::Option<&dyn enough::Stop>) -> core::result::Result<core::option::Option<AnimationFrame<'_>>, Self::Error>
+pub fn prelude::AnimationFrameDecoder::render_next_frame_owned(&mut self, core::option::Option<&dyn enough::Stop>) -> core::result::Result<core::option::Option<OwnedAnimationFrame>, Self::Error>
+pub fn prelude::AnimationFrameDecoder::render_next_frame_to_sink(&mut self, core::option::Option<&dyn enough::Stop>, &mut dyn decode::DecodeRowSink) -> core::result::Result<core::option::Option<decode::OutputInfo>, Self::Error>
+pub fn prelude::AnimationFrameDecoder::wrap_sink_error(decode::SinkError) -> Self::Error
+pub type prelude::AnimationFrameEncoder::Error: core::error::Error + core::marker::Send + core::marker::Sync + 'static
+pub fn prelude::AnimationFrameEncoder::finish(self, core::option::Option<&dyn enough::Stop>) -> core::result::Result<encode::EncodeOutput, Self::Error>
+pub fn prelude::AnimationFrameEncoder::push_frame(&mut self, zenpixels::buffer::PixelSlice<'_>, u32, core::option::Option<&dyn enough::Stop>) -> core::result::Result<(), Self::Error>
+pub fn prelude::AnimationFrameEncoder::reject(UnsupportedOperation) -> Self::Error
+pub type prelude::Decode::Error: core::error::Error + core::marker::Send + core::marker::Sync + 'static
+pub fn prelude::Decode::decode(self) -> core::result::Result<decode::DecodeOutput, Self::Error>
+pub type prelude::DecodeJob::AnimationFrameDec: decode::AnimationFrameDecoder<Error = Self::Error> + core::marker::Send + 'static
+pub type prelude::DecodeJob::Dec: decode::Decode<Error = Self::Error>
+pub type prelude::DecodeJob::Error: core::error::Error + core::marker::Send + core::marker::Sync + 'static
+pub type prelude::DecodeJob::StreamDec: decode::StreamingDecode<Error = Self::Error> + core::marker::Send
+pub fn prelude::DecodeJob::animation_frame_decoder(self, alloc::borrow::Cow<'a, [u8]>, &[zenpixels::descriptor::PixelDescriptor]) -> core::result::Result<Self::AnimationFrameDec, Self::Error>
+pub fn prelude::DecodeJob::decoder(self, alloc::borrow::Cow<'a, [u8]>, &[zenpixels::descriptor::PixelDescriptor]) -> core::result::Result<Self::Dec, Self::Error>
+pub fn prelude::DecodeJob::dyn_animation_frame_decoder(self, alloc::borrow::Cow<'a, [u8]>, &[zenpixels::descriptor::PixelDescriptor]) -> core::result::Result<alloc::boxed::Box<dyn decode::DynAnimationFrameDecoder>, encode::BoxedError> where Self: 'a, Self::AnimationFrameDec: core::marker::Send
+pub fn prelude::DecodeJob::dyn_decoder(self, alloc::borrow::Cow<'a, [u8]>, &[zenpixels::descriptor::PixelDescriptor]) -> core::result::Result<alloc::boxed::Box<(dyn decode::DynDecoder + 'a)>, encode::BoxedError> where Self: 'a
+pub fn prelude::DecodeJob::dyn_streaming_decoder(self, alloc::borrow::Cow<'a, [u8]>, &[zenpixels::descriptor::PixelDescriptor]) -> core::result::Result<alloc::boxed::Box<(dyn decode::DynStreamingDecoder + 'a)>, encode::BoxedError> where Self: 'a, Self::StreamDec: core::marker::Send
+pub fn prelude::DecodeJob::extensions(&self) -> core::option::Option<&dyn core::any::Any>
+pub fn prelude::DecodeJob::extensions_mut(&mut self) -> core::option::Option<&mut dyn core::any::Any>
+pub fn prelude::DecodeJob::output_info(&self, &[u8]) -> core::result::Result<decode::OutputInfo, Self::Error>
+pub fn prelude::DecodeJob::probe(&self, &[u8]) -> core::result::Result<ImageInfo, Self::Error>
+pub fn prelude::DecodeJob::probe_full(&self, &[u8]) -> core::result::Result<ImageInfo, Self::Error>
+pub fn prelude::DecodeJob::push_decoder(self, alloc::borrow::Cow<'a, [u8]>, &mut dyn decode::DecodeRowSink, &[zenpixels::descriptor::PixelDescriptor]) -> core::result::Result<decode::OutputInfo, Self::Error>
+pub fn prelude::DecodeJob::streaming_decoder(self, alloc::borrow::Cow<'a, [u8]>, &[zenpixels::descriptor::PixelDescriptor]) -> core::result::Result<Self::StreamDec, Self::Error>
+pub fn prelude::DecodeJob::with_crop_hint(self, u32, u32, u32, u32) -> Self
+pub fn prelude::DecodeJob::with_extract_gain_map(self, bool) -> Self
+pub fn prelude::DecodeJob::with_gain_map_render(self, gainmap::GainMapRender) -> Self
+pub fn prelude::DecodeJob::with_limits(self, ResourceLimits) -> Self
+pub fn prelude::DecodeJob::with_orientation(self, OrientationHint) -> Self
+pub fn prelude::DecodeJob::with_policy(self, decode::DecodePolicy) -> Self
+pub fn prelude::DecodeJob::with_start_frame_index(self, u32) -> Self
+pub fn prelude::DecodeJob::with_stop(self, almost_enough::stop_token::StopToken) -> Self
+pub type prelude::DecoderConfig::Error: core::error::Error + core::marker::Send + core::marker::Sync + 'static
+pub type prelude::DecoderConfig::Job<'a>: decode::DecodeJob<'a, Error = Self::Error> + 'static
+pub fn prelude::DecoderConfig::capabilities() -> &'static decode::DecodeCapabilities
+pub fn prelude::DecoderConfig::decode(self, &[u8]) -> core::result::Result<decode::DecodeOutput, Self::Error> where Self: core::marker::Sized
+pub fn prelude::DecoderConfig::estimate_decode_resources(&self, &estimate::ImageCharacteristics, &estimate::ComputeEnvironment) -> estimate::ResourceEstimate
+pub fn prelude::DecoderConfig::formats() -> &'static [ImageFormat]
+pub fn prelude::DecoderConfig::job<'a>(self) -> Self::Job
+pub fn prelude::DecoderConfig::probe(&self, &[u8]) -> core::result::Result<ImageInfo, Self::Error> where Self: core::marker::Sized
+pub fn prelude::DecoderConfig::supported_descriptors() -> &'static [zenpixels::descriptor::PixelDescriptor]
+pub fn prelude::DynAnimationFrameDecoder::as_any(&self) -> &dyn core::any::Any
+pub fn prelude::DynAnimationFrameDecoder::as_any_mut(&mut self) -> &mut dyn core::any::Any
+pub fn prelude::DynAnimationFrameDecoder::frame_count(&self) -> core::option::Option<u32>
+pub fn prelude::DynAnimationFrameDecoder::info(&self) -> &ImageInfo
+pub fn prelude::DynAnimationFrameDecoder::into_any(alloc::boxed::Box<Self>) -> alloc::boxed::Box<dyn core::any::Any>
+pub fn prelude::DynAnimationFrameDecoder::loop_count(&self) -> core::option::Option<u32>
+pub fn prelude::DynAnimationFrameDecoder::render_next_frame_owned(&mut self, core::option::Option<&dyn enough::Stop>) -> core::result::Result<core::option::Option<OwnedAnimationFrame>, encode::BoxedError>
+pub fn prelude::DynAnimationFrameDecoder::render_next_frame_to_sink(&mut self, core::option::Option<&dyn enough::Stop>, &mut dyn decode::DecodeRowSink) -> core::result::Result<core::option::Option<decode::OutputInfo>, encode::BoxedError>
+pub fn prelude::DynAnimationFrameEncoder::as_any(&self) -> &dyn core::any::Any
+pub fn prelude::DynAnimationFrameEncoder::as_any_mut(&mut self) -> &mut dyn core::any::Any
+pub fn prelude::DynAnimationFrameEncoder::finish(alloc::boxed::Box<Self>, core::option::Option<&dyn enough::Stop>) -> core::result::Result<encode::EncodeOutput, encode::BoxedError>
+pub fn prelude::DynAnimationFrameEncoder::into_any(alloc::boxed::Box<Self>) -> alloc::boxed::Box<dyn core::any::Any>
+pub fn prelude::DynAnimationFrameEncoder::push_frame(&mut self, zenpixels::buffer::PixelSlice<'_>, u32, core::option::Option<&dyn enough::Stop>) -> core::result::Result<(), encode::BoxedError>
+pub fn prelude::DynDecodeJob::extensions(&self) -> core::option::Option<&dyn core::any::Any>
+pub fn prelude::DynDecodeJob::extensions_mut(&mut self) -> core::option::Option<&mut dyn core::any::Any>
+pub fn prelude::DynDecodeJob::into_animation_frame_decoder(alloc::boxed::Box<Self>, alloc::borrow::Cow<'a, [u8]>, &[zenpixels::descriptor::PixelDescriptor]) -> core::result::Result<alloc::boxed::Box<dyn decode::DynAnimationFrameDecoder>, encode::BoxedError>
+pub fn prelude::DynDecodeJob::into_decoder(alloc::boxed::Box<Self>, alloc::borrow::Cow<'a, [u8]>, &[zenpixels::descriptor::PixelDescriptor]) -> core::result::Result<alloc::boxed::Box<(dyn decode::DynDecoder + 'a)>, encode::BoxedError>
+pub fn prelude::DynDecodeJob::into_streaming_decoder(alloc::boxed::Box<Self>, alloc::borrow::Cow<'a, [u8]>, &[zenpixels::descriptor::PixelDescriptor]) -> core::result::Result<alloc::boxed::Box<(dyn decode::DynStreamingDecoder + 'a)>, encode::BoxedError>
+pub fn prelude::DynDecodeJob::output_info(&self, &[u8]) -> core::result::Result<decode::OutputInfo, encode::BoxedError>
+pub fn prelude::DynDecodeJob::probe(&self, &[u8]) -> core::result::Result<ImageInfo, encode::BoxedError>
+pub fn prelude::DynDecodeJob::probe_full(&self, &[u8]) -> core::result::Result<ImageInfo, encode::BoxedError>
+pub fn prelude::DynDecodeJob::push_decode(alloc::boxed::Box<Self>, alloc::borrow::Cow<'a, [u8]>, &mut dyn decode::DecodeRowSink, &[zenpixels::descriptor::PixelDescriptor]) -> core::result::Result<decode::OutputInfo, encode::BoxedError>
+pub fn prelude::DynDecodeJob::set_crop_hint(&mut self, u32, u32, u32, u32)
+pub fn prelude::DynDecodeJob::set_extract_gain_map(&mut self, bool)
+pub fn prelude::DynDecodeJob::set_gain_map_render(&mut self, gainmap::GainMapRender)
+pub fn prelude::DynDecodeJob::set_limits(&mut self, ResourceLimits)
+pub fn prelude::DynDecodeJob::set_orientation(&mut self, OrientationHint)
+pub fn prelude::DynDecodeJob::set_policy(&mut self, decode::DecodePolicy)
+pub fn prelude::DynDecodeJob::set_start_frame_index(&mut self, u32)
+pub fn prelude::DynDecodeJob::set_stop(&mut self, almost_enough::stop_token::StopToken)
+pub fn prelude::DynDecoder::decode(alloc::boxed::Box<Self>) -> core::result::Result<decode::DecodeOutput, encode::BoxedError>
+pub fn prelude::DynDecoderConfig::as_any(&self) -> &dyn core::any::Any
+pub fn prelude::DynDecoderConfig::capabilities(&self) -> &'static decode::DecodeCapabilities
+pub fn prelude::DynDecoderConfig::dyn_job(&self) -> alloc::boxed::Box<(dyn decode::DynDecodeJob<'_> + '_)>
+pub fn prelude::DynDecoderConfig::estimate_decode_resources(&self, &estimate::ImageCharacteristics, &estimate::ComputeEnvironment) -> estimate::ResourceEstimate
+pub fn prelude::DynDecoderConfig::formats(&self) -> &'static [ImageFormat]
+pub fn prelude::DynDecoderConfig::supported_descriptors(&self) -> &'static [zenpixels::descriptor::PixelDescriptor]
+pub fn prelude::DynEncodeJob::extensions(&self) -> core::option::Option<&dyn core::any::Any>
+pub fn prelude::DynEncodeJob::extensions_mut(&mut self) -> core::option::Option<&mut dyn core::any::Any>
+pub fn prelude::DynEncodeJob::into_animation_frame_encoder(alloc::boxed::Box<Self>) -> core::result::Result<alloc::boxed::Box<dyn encode::DynAnimationFrameEncoder>, encode::BoxedError>
+pub fn prelude::DynEncodeJob::into_encoder(alloc::boxed::Box<Self>) -> core::result::Result<alloc::boxed::Box<dyn encode::DynEncoder>, encode::BoxedError>
+pub fn prelude::DynEncodeJob::set_canvas_size(&mut self, u32, u32)
+pub fn prelude::DynEncodeJob::set_limits(&mut self, ResourceLimits)
+pub fn prelude::DynEncodeJob::set_loop_count(&mut self, core::option::Option<u32>)
+pub fn prelude::DynEncodeJob::set_metadata(&mut self, Metadata)
+pub fn prelude::DynEncodeJob::set_metadata_policy(&mut self, Metadata, MetadataPolicy)
+pub fn prelude::DynEncodeJob::set_policy(&mut self, encode::EncodePolicy)
+pub fn prelude::DynEncodeJob::set_stop(&mut self, almost_enough::stop_token::StopToken)
+pub fn prelude::DynEncoder::encode(alloc::boxed::Box<Self>, zenpixels::buffer::PixelSlice<'_>) -> core::result::Result<encode::EncodeOutput, encode::BoxedError>
+pub fn prelude::DynEncoder::encode_from(alloc::boxed::Box<Self>, &mut dyn core::ops::function::FnMut(u32, zenpixels::buffer::PixelSliceMut<'_>) -> usize) -> core::result::Result<encode::EncodeOutput, encode::BoxedError>
+pub fn prelude::DynEncoder::encode_srgba8(alloc::boxed::Box<Self>, &mut [u8], bool, u32, u32, u32) -> core::result::Result<encode::EncodeOutput, encode::BoxedError>
+pub fn prelude::DynEncoder::finish(alloc::boxed::Box<Self>) -> core::result::Result<encode::EncodeOutput, encode::BoxedError>
+pub fn prelude::DynEncoder::preferred_strip_height(&self) -> u32
+pub fn prelude::DynEncoder::push_rows(&mut self, zenpixels::buffer::PixelSlice<'_>) -> core::result::Result<(), encode::BoxedError>
+pub fn prelude::DynEncoderConfig::as_any(&self) -> &dyn core::any::Any
+pub fn prelude::DynEncoderConfig::capabilities(&self) -> &'static encode::EncodeCapabilities
+pub fn prelude::DynEncoderConfig::dyn_job(&self) -> alloc::boxed::Box<(dyn encode::DynEncodeJob + 'static)>
+pub fn prelude::DynEncoderConfig::estimate_encode_resources(&self, &estimate::ImageCharacteristics, &estimate::ComputeEnvironment) -> estimate::ResourceEstimate
+pub fn prelude::DynEncoderConfig::format(&self) -> ImageFormat
+pub fn prelude::DynEncoderConfig::supported_descriptors(&self) -> &'static [zenpixels::descriptor::PixelDescriptor]
+pub fn prelude::DynStreamingDecoder::info(&self) -> &ImageInfo
+pub fn prelude::DynStreamingDecoder::next_batch(&mut self) -> core::result::Result<core::option::Option<(u32, zenpixels::buffer::PixelSlice<'_>)>, encode::BoxedError>
+pub type prelude::EncodeJob::AnimationFrameEnc: core::marker::Sized + core::marker::Send + 'static
+pub type prelude::EncodeJob::Enc: core::marker::Sized + 'static
+pub type prelude::EncodeJob::Error: core::error::Error + core::marker::Send + core::marker::Sync + 'static
+pub fn prelude::EncodeJob::animation_frame_encoder(self) -> core::result::Result<Self::AnimationFrameEnc, Self::Error>
+pub fn prelude::EncodeJob::dyn_animation_frame_encoder(self) -> core::result::Result<alloc::boxed::Box<dyn encode::DynAnimationFrameEncoder>, encode::BoxedError> where Self::AnimationFrameEnc: encode::AnimationFrameEncoder + core::marker::Send
+pub fn prelude::EncodeJob::dyn_encoder(self) -> core::result::Result<alloc::boxed::Box<dyn encode::DynEncoder>, encode::BoxedError> where Self::Enc: encode::Encoder + core::marker::Send
+pub fn prelude::EncodeJob::encoder(self) -> core::result::Result<Self::Enc, Self::Error>
+pub fn prelude::EncodeJob::extensions(&self) -> core::option::Option<&dyn core::any::Any>
+pub fn prelude::EncodeJob::extensions_mut(&mut self) -> core::option::Option<&mut dyn core::any::Any>
+pub fn prelude::EncodeJob::with_canvas_size(self, u32, u32) -> Self
+pub fn prelude::EncodeJob::with_gain_map_encoded(self, gainmap::GainMapSource) -> core::result::Result<Self, Self::Error> where Self::Enc: encode::Encoder<Error = Self::Error>
+pub fn prelude::EncodeJob::with_gain_map_pixels(self, gainmap::DecodedGainMap) -> core::result::Result<Self, Self::Error> where Self::Enc: encode::Encoder<Error = Self::Error>
+pub fn prelude::EncodeJob::with_limits(self, ResourceLimits) -> Self
+pub fn prelude::EncodeJob::with_loop_count(self, core::option::Option<u32>) -> Self
+pub fn prelude::EncodeJob::with_metadata(self, Metadata) -> Self
+pub fn prelude::EncodeJob::with_metadata_policy(self, Metadata, MetadataPolicy) -> Self
+pub fn prelude::EncodeJob::with_policy(self, encode::EncodePolicy) -> Self
+pub fn prelude::EncodeJob::with_stop(self, almost_enough::stop_token::StopToken) -> Self
+pub type prelude::Encoder::Error: core::error::Error + core::marker::Send + core::marker::Sync + 'static
+pub fn prelude::Encoder::encode(self, zenpixels::buffer::PixelSlice<'_>) -> core::result::Result<encode::EncodeOutput, Self::Error>
+pub fn prelude::Encoder::encode_from(self, &mut dyn core::ops::function::FnMut(u32, zenpixels::buffer::PixelSliceMut<'_>) -> usize) -> core::result::Result<encode::EncodeOutput, Self::Error>
+pub fn prelude::Encoder::encode_srgba8(self, &mut [u8], bool, u32, u32, u32) -> core::result::Result<encode::EncodeOutput, Self::Error>
+pub fn prelude::Encoder::finish(self) -> core::result::Result<encode::EncodeOutput, Self::Error>
+pub fn prelude::Encoder::preferred_strip_height(&self) -> u32
+pub fn prelude::Encoder::push_rows(&mut self, zenpixels::buffer::PixelSlice<'_>) -> core::result::Result<(), Self::Error>
+pub fn prelude::Encoder::reject(UnsupportedOperation) -> Self::Error
+pub type prelude::EncoderConfig::Error: core::error::Error + core::marker::Send + core::marker::Sync + 'static
+pub type prelude::EncoderConfig::Job: encode::EncodeJob<Error = Self::Error>
+pub fn prelude::EncoderConfig::alpha_quality(&self) -> core::option::Option<f32>
+pub fn prelude::EncoderConfig::capabilities() -> &'static encode::EncodeCapabilities
+pub fn prelude::EncoderConfig::encode(self, zenpixels::buffer::PixelSlice<'_>) -> core::result::Result<encode::EncodeOutput, Self::Error> where Self: core::marker::Sized, <Self::Job as encode::EncodeJob>::Enc: encode::Encoder<Error = Self::Error>
+pub fn prelude::EncoderConfig::estimate_encode_resources(&self, &estimate::ImageCharacteristics, &estimate::ComputeEnvironment) -> estimate::ResourceEstimate
+pub fn prelude::EncoderConfig::format() -> ImageFormat
+pub fn prelude::EncoderConfig::generic_effort(&self) -> core::option::Option<i32>
+pub fn prelude::EncoderConfig::generic_quality(&self) -> core::option::Option<f32>
+pub fn prelude::EncoderConfig::is_lossless(&self) -> core::option::Option<bool>
+pub fn prelude::EncoderConfig::job(self) -> Self::Job
+pub fn prelude::EncoderConfig::resolved_target_fidelity(&self) -> core::option::Option<encode::Fidelity>
+pub fn prelude::EncoderConfig::supported_descriptors() -> &'static [zenpixels::descriptor::PixelDescriptor]
+pub fn prelude::EncoderConfig::with_alpha_quality(self, f32) -> Self
+pub fn prelude::EncoderConfig::with_fidelity(self, encode::Fidelity) -> Self
+pub fn prelude::EncoderConfig::with_generic_effort(self, i32) -> Self
+pub fn prelude::EncoderConfig::with_generic_quality(self, f32) -> Self
+pub fn prelude::EncoderConfig::with_lossless(self, bool) -> Self
+pub type prelude::StreamingDecode::Error: core::error::Error + core::marker::Send + core::marker::Sync + 'static
+pub fn prelude::StreamingDecode::info(&self) -> &ImageInfo
+pub fn prelude::StreamingDecode::next_batch(&mut self) -> core::result::Result<core::option::Option<(u32, zenpixels::buffer::PixelSlice<'_>)>, Self::Error>
 #[non_exhaustive] pub enum AllocPreference
 pub AllocPreference::CodecDefault
 pub AllocPreference::Fallible
@@ -702,6 +863,11 @@ pub AllocPreference::Infallible
 pub CicpEmission::Never
 pub CicpEmission::WhereValidCarrier
 pub CicpEmission::WhereverSupported
+#[non_exhaustive] pub enum CodecSetError
+pub CodecSetError::Codec(encode::BoxedError)
+pub CodecSetError::NoDecoder(ImageFormat)
+pub CodecSetError::NoEncoder(ImageFormat)
+pub CodecSetError::UnrecognizedFormat
 #[non_exhaustive] pub enum ColorEmitPolicy
 pub ColorEmitPolicy::Balanced
 pub ColorEmitPolicy::Compact
@@ -926,6 +1092,33 @@ pub fn CodecError::of<E>(whereat::at::At<E>) -> whereat::at::At<CodecError> wher
 pub fn CodecError::with_codec(self, core::option::Option<&'static str>) -> Self
 pub struct CodecIoKind
 pub const fn CodecIoKind::opaque() -> Self
+pub struct CodecSet
+pub fn CodecSet::animation_decoder<'a>(&'a self, &'a [u8], &[zenpixels::descriptor::PixelDescriptor]) -> core::result::Result<alloc::boxed::Box<dyn decode::DynAnimationFrameDecoder>, CodecSetError>
+pub fn CodecSet::can_decode(&self, ImageFormat) -> bool
+pub fn CodecSet::can_encode(&self, ImageFormat) -> bool
+pub fn CodecSet::decodable_formats(&self) -> impl core::iter::traits::iterator::Iterator<Item = ImageFormat> + '_
+pub fn CodecSet::decode<'a>(&'a self, &'a [u8]) -> core::result::Result<decode::DecodeOutput, CodecSetError>
+pub fn CodecSet::decode_as<'a>(&'a self, ImageFormat, &'a [u8], &[zenpixels::descriptor::PixelDescriptor]) -> core::result::Result<decode::DecodeOutput, CodecSetError>
+pub fn CodecSet::decode_job<'a>(&'a self, ImageFormat) -> core::result::Result<alloc::boxed::Box<(dyn decode::DynDecodeJob<'a> + 'a)>, CodecSetError>
+pub fn CodecSet::decode_preferring<'a>(&'a self, &'a [u8], &[zenpixels::descriptor::PixelDescriptor]) -> core::result::Result<decode::DecodeOutput, CodecSetError>
+pub fn CodecSet::decoder_for(&self, ImageFormat) -> core::option::Option<&dyn decode::DynDecoderConfig>
+pub fn CodecSet::detect(&self, &[u8]) -> core::option::Option<ImageFormat>
+pub fn CodecSet::encodable_formats(&self) -> impl core::iter::traits::iterator::Iterator<Item = ImageFormat> + '_
+pub fn CodecSet::encode(&self, ImageFormat, zenpixels::buffer::PixelSlice<'_>) -> core::result::Result<encode::EncodeOutput, CodecSetError>
+pub fn CodecSet::encode_job(&self, ImageFormat) -> core::result::Result<alloc::boxed::Box<dyn encode::DynEncodeJob>, CodecSetError>
+pub fn CodecSet::encode_job_with(&self, ImageFormat, encode::Fidelity) -> core::result::Result<alloc::boxed::Box<dyn encode::DynEncodeJob>, CodecSetError>
+pub fn CodecSet::encode_with(&self, ImageFormat, encode::Fidelity, zenpixels::buffer::PixelSlice<'_>) -> core::result::Result<encode::EncodeOutput, CodecSetError>
+pub fn CodecSet::encoder_for(&self, ImageFormat) -> core::option::Option<&dyn encode::DynEncoderConfig>
+pub fn CodecSet::new() -> Self
+pub fn CodecSet::probe<'a>(&'a self, &'a [u8]) -> core::result::Result<ImageInfo, CodecSetError>
+pub fn CodecSet::push_decode<'a>(&'a self, &'a [u8], &mut dyn decode::DecodeRowSink, &[zenpixels::descriptor::PixelDescriptor]) -> core::result::Result<decode::OutputInfo, CodecSetError>
+pub fn CodecSet::streaming_decoder<'a>(&'a self, &'a [u8], &[zenpixels::descriptor::PixelDescriptor]) -> core::result::Result<alloc::boxed::Box<(dyn decode::DynStreamingDecoder + 'a)>, CodecSetError>
+pub fn CodecSet::with_decode_policy(self, decode::DecodePolicy) -> Self
+pub fn CodecSet::with_decoder(self, impl decode::DecoderConfig + 'static) -> Self
+pub fn CodecSet::with_encode_policy(self, encode::EncodePolicy) -> Self
+pub fn CodecSet::with_encoder<C>(self, C) -> Self where C: encode::EncoderConfig + 'static, <<C as encode::EncoderConfig>::Job as encode::EncodeJob>::Enc: encode::Encoder + core::marker::Send, <<C as encode::EncoderConfig>::Job as encode::EncodeJob>::AnimationFrameEnc: encode::AnimationFrameEncoder
+pub fn CodecSet::with_limits(self, ResourceLimits) -> Self
+pub fn CodecSet::with_stop(self, almost_enough::stop_token::StopToken) -> Self
 #[non_exhaustive] pub struct ColorEmitFields
 pub ColorEmitFields::cicp: CicpEmission
 pub ColorEmitFields::icc: IccRetention
@@ -1230,7 +1423,7 @@ pub fn find_cause<'a, T: core::error::Error + 'static>(&'a (dyn core::error::Err
 pub fn icc_extract_cicp(&[u8]) -> core::option::Option<(u8, u8, u8, bool)> [also: icc]
 pub fn resolve_color_emit(&SourceColor, &encode::EncodeCapabilities, ColorEmitPolicy) -> ColorEmitPlan
 
-## trait impls (80 types)
+## trait impls (82 types)
 
 (): encode::AnimationFrameEncoder
 (dyn core::error::Error + 'static): CodecErrorExt
@@ -1241,6 +1434,8 @@ AnimationFrame<'_>: Debug
 CicpEmission: Clone, Copy, Debug, Default, Eq, PartialEq
 CodecError: CategorizedError, Debug, Display, Error
 CodecIoKind: Clone, Copy, Debug, Default, Eq, Hash, PartialEq
+CodecSet: Clone, Debug, Default
+CodecSetError: Debug, Display, Error, From<alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync)>>
 ColorEmitFields: Clone, Copy, Debug, Default, Eq, PartialEq
 ColorEmitPlan: Clone, Debug, PartialEq
 ColorEmitPolicy: Clone, Copy, Debug, Default, Eq, PartialEq
@@ -1314,11 +1509,15 @@ helpers::IccMatchTolerance: Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd
 whereat::at::At<E>: CategorizedError
 impl<C> decode::DynDecoderConfig for C where C: decode::DecoderConfig + 'static
 impl<C> encode::DynEncoderConfig for C where C: encode::EncoderConfig + 'static, <<C as encode::EncoderConfig>::Job as encode::EncodeJob>::Enc: encode::Encoder + core::marker::Send, <<C as encode::EncoderConfig>::Job as encode::EncodeJob>::AnimationFrameEnc: encode::AnimationFrameEncoder
+impl<C> decode::DynDecoderConfig for C where C: decode::DecoderConfig + 'static
+impl<C> encode::DynEncoderConfig for C where C: encode::EncoderConfig + 'static, <<C as encode::EncoderConfig>::Job as encode::EncodeJob>::Enc: encode::Encoder + core::marker::Send, <<C as encode::EncoderConfig>::Job as encode::EncodeJob>::AnimationFrameEnc: encode::AnimationFrameEncoder
 
 ## auto traits
 
 67 types implement all of: Freeze, RefUnwindSafe, Send, Sync, Unpin, UnwindSafe
 CodecError: !RefUnwindSafe !UnwindSafe
+CodecSet: !RefUnwindSafe !UnwindSafe
+CodecSetError: !RefUnwindSafe !UnwindSafe
 Extensions: !RefUnwindSafe !UnwindSafe
 ImageInfo: !RefUnwindSafe !UnwindSafe
 OwnedAnimationFrame: !RefUnwindSafe !UnwindSafe

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -104,6 +104,9 @@ trait EncodeJob: Sized {
 
     fn encoder(self) -> Result<Self::Enc, Self::Error>;
     fn animation_frame_encoder(self) -> Result<Self::AnimationFrameEnc, Self::Error>;
+    // One-shot: encode with this job's config (== self.encoder()?.encode(pixels))
+    fn encode(self, pixels: PixelSlice<'_>) -> Result<EncodeOutput, Self::Error>
+        where Self::Enc: Encoder<Error = Self::Error>;
 
     // Type-erased convenience (default impls via shims)
     fn dyn_encoder(self) -> Result<Box<dyn DynEncoder>, BoxedError>
@@ -321,6 +324,8 @@ trait DynEncodeJob {
     fn set_loop_count(&mut self, count: Option<u32>);
     fn extensions(&self) -> Option<&dyn Any>;
     fn extensions_mut(&mut self) -> Option<&mut dyn Any>;
+    // One-shot: encode with this job's config (== self.into_encoder()?.encode(pixels))
+    fn encode(self: Box<Self>, pixels: PixelSlice<'_>) -> Result<EncodeOutput, BoxedError>;
     fn into_encoder(self: Box<Self>) -> Result<Box<dyn DynEncoder>, BoxedError>;
     fn into_animation_frame_encoder(self: Box<Self>) -> Result<Box<dyn DynAnimationFrameEncoder>, BoxedError>;
 }

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -879,6 +879,9 @@ impl CodecSet {
         compute: &ComputeEnvironment) -> Result<ResourceEstimate, CodecSetError>;
     fn estimate_decode(&self, format: ImageFormat, image: &ImageCharacteristics,
         compute: &ComputeEnvironment) -> Result<ResourceEstimate, CodecSetError>;
+    // Pixels-based: reads dims + descriptor off the slice, then estimate_encode.
+    fn estimate_encode_of(&self, format: ImageFormat, pixels: PixelSlice<'_>,
+        compute: &ComputeEnvironment) -> Result<ResourceEstimate, CodecSetError>;
     // Bytes-based: probe → estimate_decode at the decoder's native output.
     fn estimate_decode_of(&self, data: &[u8], compute: &ComputeEnvironment)
         -> Result<ResourceEstimate, CodecSetError>;

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -877,6 +877,11 @@ impl CodecSet {
     fn encode_job(&self, format: ImageFormat) -> Result<Box<dyn DynEncodeJob>, CodecSetError>;
     fn encode_job_with(&self, format: ImageFormat, fidelity: Fidelity)
         -> Result<Box<dyn DynEncodeJob>, CodecSetError>;
+    // One-call proxy op: decode -> carry source metadata (filtered) -> encode.
+    // Single-image, no pixel processing, no descriptor adaptation.
+    fn transcode(&self, input: &[u8], target: ImageFormat, fidelity: Fidelity,
+        metadata: MetadataPolicy, color: ColorEmitPolicy)
+        -> Result<EncodeOutput, CodecSetError>;
 
     // Resource estimation: forward to the registered codec's cost model
     // (unknown() if it has none); NoEncoder / NoDecoder if unregistered.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -879,6 +879,9 @@ impl CodecSet {
         compute: &ComputeEnvironment) -> Result<ResourceEstimate, CodecSetError>;
     fn estimate_decode(&self, format: ImageFormat, image: &ImageCharacteristics,
         compute: &ComputeEnvironment) -> Result<ResourceEstimate, CodecSetError>;
+    // Bytes-based: probe → estimate_decode at the decoder's native output.
+    fn estimate_decode_of(&self, data: &[u8], compute: &ComputeEnvironment)
+        -> Result<ResourceEstimate, CodecSetError>;
 }
 
 enum CodecSetError {

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -72,6 +72,10 @@ trait EncoderConfig: Clone + Send + Sync {
     fn alpha_quality(&self) -> Option<f32>;     // default: None
 
     fn job(self) -> Self::Job;
+
+    // Provided one-shot (default body; requires Job::Enc: Encoder<Error = Self::Error>):
+    // job() → encoder() → encode(pixels) with default job settings.
+    fn encode(self, pixels: PixelSlice<'_>) -> Result<EncodeOutput, Self::Error>;
 }
 ```
 
@@ -172,6 +176,10 @@ trait DecoderConfig: Clone + Send + Sync {
     fn capabilities() -> &'static DecodeCapabilities;  // default: EMPTY
 
     fn job<'a>(self) -> Self::Job<'a>;
+
+    // Provided one-shots (default bodies) with default job settings:
+    fn decode(self, data: &[u8]) -> Result<DecodeOutput, Self::Error>;  // native pixel format
+    fn probe(&self, data: &[u8]) -> Result<ImageInfo, Self::Error>;     // header parse only
 }
 ```
 
@@ -801,6 +809,97 @@ Metadata for a format: name, extensions, MIME types, capability flags, detection
 ### `ImageFormatRegistry`
 
 Thread-safe registry for custom formats. `common()` returns built-in formats.
+
+---
+
+## CodecSet (multi-codec registry)
+
+Runtime set of registered codec configs with one entry point per operation.
+`Send + Sync + 'static`, `Clone`, `Debug`, `Default`; every operation takes
+`&self`, so one instance can be shared app-wide (`LazyLock` / `OnceLock` /
+`Arc`, or `Box::leak` in `no_std`).
+
+```rust
+struct CodecSet { /* private */ }
+
+impl CodecSet {
+    fn new() -> Self;
+
+    // Registration — self-describing via DecoderConfig::formats() /
+    // EncoderConfig::format(); first registered wins per format.
+    fn with_decoder(self, config: impl DecoderConfig + 'static) -> Self;
+    fn with_encoder<C>(self, config: C) -> Self
+        where C: EncoderConfig + 'static,
+              <C::Job as EncodeJob>::Enc: Encoder + Send,
+              <C::Job as EncodeJob>::AnimationFrameEnc: AnimationFrameEncoder;
+
+    // Defaults stamped onto every job the set creates.
+    fn with_limits(self, limits: ResourceLimits) -> Self;
+    fn with_stop(self, stop: StopToken) -> Self;
+    fn with_decode_policy(self, policy: DecodePolicy) -> Self;
+    fn with_encode_policy(self, policy: EncodePolicy) -> Self;
+
+    // Queries.
+    fn detect(&self, data: &[u8]) -> Option<ImageFormat>;
+    fn can_decode(&self, format: ImageFormat) -> bool;
+    fn can_encode(&self, format: ImageFormat) -> bool;
+    fn decoder_for(&self, format: ImageFormat) -> Option<&dyn DynDecoderConfig>;
+    fn encoder_for(&self, format: ImageFormat) -> Option<&dyn DynEncoderConfig>;
+    fn decodable_formats(&self) -> impl Iterator<Item = ImageFormat> + '_;
+    fn encodable_formats(&self) -> impl Iterator<Item = ImageFormat> + '_;
+
+    // Decode: detect → stamped job → run.
+    fn probe<'a>(&'a self, data: &'a [u8]) -> Result<ImageInfo, CodecSetError>;
+    fn decode<'a>(&'a self, data: &'a [u8]) -> Result<DecodeOutput, CodecSetError>;
+    fn decode_preferring<'a>(&'a self, data: &'a [u8], preferred: &[PixelDescriptor])
+        -> Result<DecodeOutput, CodecSetError>;
+    fn decode_as<'a>(&'a self, format: ImageFormat, data: &'a [u8], preferred: &[PixelDescriptor])
+        -> Result<DecodeOutput, CodecSetError>;
+    fn push_decode<'a>(&'a self, data: &'a [u8], sink: &mut dyn DecodeRowSink,
+        preferred: &[PixelDescriptor]) -> Result<OutputInfo, CodecSetError>;
+    fn animation_decoder<'a>(&'a self, data: &'a [u8], preferred: &[PixelDescriptor])
+        -> Result<Box<dyn DynAnimationFrameDecoder>, CodecSetError>;   // 'static result
+    fn streaming_decoder<'a>(&'a self, data: &'a [u8], preferred: &[PixelDescriptor])
+        -> Result<Box<dyn DynStreamingDecoder + 'a>, CodecSetError>;   // borrows set + data
+    fn decode_job<'a>(&'a self, format: ImageFormat)
+        -> Result<Box<dyn DynDecodeJob<'a> + 'a>, CodecSetError>;      // escape hatch (hints, etc.)
+
+    // Encode: format-keyed; the registered config is a template.
+    fn encode(&self, format: ImageFormat, pixels: PixelSlice<'_>)
+        -> Result<EncodeOutput, CodecSetError>;
+    fn encode_with(&self, format: ImageFormat, fidelity: Fidelity, pixels: PixelSlice<'_>)
+        -> Result<EncodeOutput, CodecSetError>;                        // clones the template
+    fn encode_job(&self, format: ImageFormat) -> Result<Box<dyn DynEncodeJob>, CodecSetError>;
+    fn encode_job_with(&self, format: ImageFormat, fidelity: Fidelity)
+        -> Result<Box<dyn DynEncodeJob>, CodecSetError>;
+}
+
+enum CodecSetError {
+    UnrecognizedFormat,        // detect() matched nothing registered
+    NoDecoder(ImageFormat),    // known format, nothing registered for it
+    NoEncoder(ImageFormat),
+    Codec(BoxedError),         // codec failure; source() exposes the chain
+}
+```
+
+Semantics:
+
+- **Detection** consults only formats with a registered decoder: built-ins in
+  `ImageFormatRegistry::common()` priority order (so AVIF-before-HEIC and
+  DNG-before-TIFF disambiguation is preserved regardless of registration
+  order), then `Custom` formats in registration order.
+- **Encoder templates**: codec-specific options are set on the concrete config
+  before registration; `encode_with` / `encode_job_with` clone the template
+  and apply a per-call `Fidelity` to the clone.
+- **Job escape hatches**: `decode_job` / `encode_job` return the stamped
+  `Dyn*Job` for per-operation control (decode hints, metadata, canvas/loop
+  settings) before running an executor.
+
+## Prelude
+
+`zencodec::prelude::*` imports every encode/decode trait (generic and dyn
+variants) so `.job()`, `.decoder()`, `.encode()`, `.next_batch()`, … resolve
+with one `use`. Types are not included.
 
 ---
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -872,6 +872,13 @@ impl CodecSet {
     fn encode_job(&self, format: ImageFormat) -> Result<Box<dyn DynEncodeJob>, CodecSetError>;
     fn encode_job_with(&self, format: ImageFormat, fidelity: Fidelity)
         -> Result<Box<dyn DynEncodeJob>, CodecSetError>;
+
+    // Resource estimation: forward to the registered codec's cost model
+    // (unknown() if it has none); NoEncoder / NoDecoder if unregistered.
+    fn estimate_encode(&self, format: ImageFormat, image: &ImageCharacteristics,
+        compute: &ComputeEnvironment) -> Result<ResourceEstimate, CodecSetError>;
+    fn estimate_decode(&self, format: ImageFormat, image: &ImageCharacteristics,
+        compute: &ComputeEnvironment) -> Result<ResourceEstimate, CodecSetError>;
 }
 
 enum CodecSetError {

--- a/src/estimate.rs
+++ b/src/estimate.rs
@@ -46,7 +46,7 @@ use zenpixels::PixelDescriptor;
 ///     else if archmage::X64V3Token::summon().is_some() { SimdTier::X86V3 }
 ///     else if archmage::X64V2Token::summon().is_some() { SimdTier::X86V2 }
 ///     else { SimdTier::X86V1 };
-/// let env = ComputeEnvironment::new().with_cores(8).with_simd_tier(tier);
+/// let env = ComputeEnvironment::conservative().with_cores(8).with_simd_tier(tier);
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive]
@@ -79,8 +79,10 @@ pub enum SimdTier {
 
 /// Hardware + runtime conditions for a resource estimate.
 ///
-/// Sealed and growable — construct via [`ComputeEnvironment::new`] and refine
-/// with the `with_*` setters; read with the accessors. Carries the available
+/// Sealed and growable — construct via
+/// [`conservative()`](ComputeEnvironment::conservative) (or
+/// [`host()`](ComputeEnvironment::host) on `std`) and refine with the `with_*`
+/// setters; read with the accessors. Carries the available
 /// core count + an optional [`SimdTier`] today; new fields (RAM, load factor,
 /// GPU) are additive.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -92,15 +94,47 @@ pub struct ComputeEnvironment {
 }
 
 impl ComputeEnvironment {
-    /// A single-core environment with unknown RAM and unspecified SIMD tier
-    /// (the conservative default).
+    /// The conservative baseline: a single core, unknown RAM, unspecified SIMD
+    /// tier. Estimates built on it assume serial execution on unknown hardware —
+    /// safe (never over-counts cores) but pessimistic on wall time.
+    ///
+    /// Refine with the `with_*` setters, or use [`host()`](Self::host) to detect
+    /// the running machine.
     #[must_use]
-    pub fn new() -> Self {
+    pub fn conservative() -> Self {
         Self {
             available_cores: 1,
             available_ram_bytes: None,
             simd_tier: None,
         }
+    }
+
+    /// Detect the machine running this call: [`available_parallelism`] cores and
+    /// [`SimdTier::CurrentHost`]. RAM is left unknown — `std` exposes no portable
+    /// query; set it with
+    /// [`with_available_ram_bytes`](Self::with_available_ram_bytes) if you have
+    /// it (e.g. via the `sysinfo` crate).
+    ///
+    /// Requires the `std` feature; in `no_std`, build from
+    /// [`conservative()`](Self::conservative) + the `with_*` setters instead.
+    ///
+    /// [`available_parallelism`]: std::thread::available_parallelism
+    #[cfg(feature = "std")]
+    #[must_use]
+    pub fn host() -> Self {
+        Self::conservative()
+            .with_cores(std::thread::available_parallelism().map_or(1, |n| n.get()))
+            .with_simd_tier(SimdTier::CurrentHost)
+    }
+
+    /// A single-core environment with unknown RAM and unspecified SIMD tier.
+    #[must_use]
+    #[deprecated(
+        since = "0.1.27",
+        note = "make construction explicit: `conservative()` for the single-core baseline, or `host()` (std) to detect the running machine"
+    )]
+    pub fn new() -> Self {
+        Self::conservative()
     }
 
     /// Number of CPU cores available to the operation (clamped to ≥ 1). On
@@ -148,7 +182,7 @@ impl ComputeEnvironment {
 
 impl Default for ComputeEnvironment {
     fn default() -> Self {
-        Self::new()
+        Self::conservative()
     }
 }
 
@@ -454,23 +488,43 @@ mod tests {
 
     #[test]
     fn compute_environment_builder_clamps_and_defaults() {
-        assert_eq!(ComputeEnvironment::new().cores(), 1);
-        assert_eq!(ComputeEnvironment::new().with_cores(0).cores(), 1);
+        assert_eq!(ComputeEnvironment::conservative().cores(), 1);
+        assert_eq!(ComputeEnvironment::conservative().with_cores(0).cores(), 1);
         assert_eq!(ComputeEnvironment::default().with_cores(16).cores(), 16);
         assert_eq!(
-            ComputeEnvironment::new()
+            ComputeEnvironment::conservative()
                 .with_available_ram_bytes(1 << 30)
                 .available_ram_bytes(),
             Some(1 << 30)
         );
         // SIMD tier defaults to unspecified; the builder sets it.
-        assert_eq!(ComputeEnvironment::new().simd_tier(), None);
+        assert_eq!(ComputeEnvironment::conservative().simd_tier(), None);
         assert_eq!(
-            ComputeEnvironment::new()
+            ComputeEnvironment::conservative()
                 .with_simd_tier(SimdTier::X86V3)
                 .simd_tier(),
             Some(SimdTier::X86V3)
         );
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_new_still_delegates_to_conservative() {
+        assert_eq!(
+            ComputeEnvironment::new(),
+            ComputeEnvironment::conservative()
+        );
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn host_detects_cores_and_current_simd() {
+        let env = ComputeEnvironment::host();
+        // available_parallelism() is >= 1; host() clamps and records it.
+        assert!(env.cores() >= 1);
+        assert_eq!(env.simd_tier(), Some(SimdTier::CurrentHost));
+        // RAM stays unknown — std has no portable query.
+        assert_eq!(env.available_ram_bytes(), None);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,12 @@
 //! # Shared types (root)
 //!
 //! - [`ImageFormat`] — format detection from magic bytes
+//! - [`CodecSet`] — multi-codec registry: register configs once, then
+//!   detect-and-decode or encode-by-format through one shared `&self` handle
 //! - [`ImageInfo`] / [`Metadata`] / [`Orientation`] / [`OrientationHint`] — image metadata
 //! - [`ResourceLimits`] / [`ThreadingPolicy`] — resource limit and threading configuration
 //! - [`UnsupportedOperation`] / [`CodecErrorExt`] — standard unsupported operation reporting and error chain inspection
+//! - [`prelude`] — one-import bundle of all encode/decode traits
 //!
 //! # Re-exported crates
 //!
@@ -72,6 +75,7 @@ mod negotiate;
 mod orientation;
 mod output;
 mod policy;
+mod set;
 mod sink;
 mod traits;
 
@@ -103,6 +107,7 @@ pub use limits::{AllocPreference, LimitExceeded, LimitKind, ResourceLimits, Thre
 pub use metadata::{IccRetention, Metadata, MetadataFields, MetadataPolicy};
 pub use orientation::{Orientation, OrientationHint};
 pub use output::{AnimationFrame, OwnedAnimationFrame};
+pub use set::{CodecSet, CodecSetError};
 pub use zenpixels::ColorAuthority;
 
 pub use capabilities::UnsupportedOperation;
@@ -236,4 +241,21 @@ pub mod decode {
 
     // Gain-map decode intent + decoded payloads (the math stays in `ultrahdr-core`).
     pub use crate::gainmap::{DecodedGainMap, GainMapRender};
+}
+
+/// One-import trait bundle: `use zencodec::prelude::*;`.
+///
+/// Brings every encode/decode trait into scope so `.job()`, `.decoder()`,
+/// `.encode()`, `.next_batch()`, and the other trait methods resolve without
+/// hunting down individual `use` lines. Types are *not* included — import
+/// those from the crate root or the [`encode`]/[`decode`] modules.
+pub mod prelude {
+    pub use crate::decode::{
+        AnimationFrameDecoder, Decode, DecodeJob, DecoderConfig, DynAnimationFrameDecoder,
+        DynDecodeJob, DynDecoder, DynDecoderConfig, DynStreamingDecoder, StreamingDecode,
+    };
+    pub use crate::encode::{
+        AnimationFrameEncoder, DynAnimationFrameEncoder, DynEncodeJob, DynEncoder,
+        DynEncoderConfig, EncodeJob, Encoder, EncoderConfig,
+    };
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -531,6 +531,25 @@ impl CodecSet {
             .estimate_encode_resources(image, compute))
     }
 
+    /// Predict encode resources for the `pixels` you are about to hand the
+    /// encoder, reading their dimensions and format straight off the slice —
+    /// the pixels-based counterpart to [`estimate_encode`](Self::estimate_encode)
+    /// (as [`estimate_decode_of`](Self::estimate_decode_of) is to
+    /// [`estimate_decode`](Self::estimate_decode)).
+    ///
+    /// Saves building an [`ImageCharacteristics`] by hand when you already hold
+    /// the pixel slice. Errors only with [`NoEncoder`](CodecSetError::NoEncoder)
+    /// when no encoder for `format` is registered.
+    pub fn estimate_encode_of(
+        &self,
+        format: ImageFormat,
+        pixels: PixelSlice<'_>,
+        compute: &ComputeEnvironment,
+    ) -> Result<ResourceEstimate, CodecSetError> {
+        let image = ImageCharacteristics::new(pixels.width(), pixels.rows(), pixels.descriptor());
+        self.estimate_encode(format, &image, compute)
+    }
+
     /// Predict the peak memory and wall-time of **decoding** an image with the
     /// given [`ImageCharacteristics`] as `format` on `compute`, without
     /// decoding anything.

--- a/src/set.rs
+++ b/src/set.rs
@@ -521,15 +521,17 @@ impl CodecSet {
     ///   [`animation_decoder`](Self::animation_decoder) + [`encode_job`](Self::encode_job).
     /// - **No pixel processing** — recompresses at the decoded dimensions and
     ///   pixel format; no resize, crop, or CMS conversion.
-    /// - **No descriptor adaptation** — the decoder's output pixels go straight
-    ///   to the encoder. If the decoder emits a [`PixelDescriptor`] the `target`
-    ///   encoder does not list in
+    /// - **Meets on a shared pixel format, no adaptation** — the decoder is
+    ///   asked (via [`decode_preferring`](Self::decode_preferring)) to emit a
+    ///   [`PixelDescriptor`] the `target` encoder lists in
     ///   [`supported_descriptors`](crate::traits::EncoderConfig::supported_descriptors),
-    ///   the encoder's error surfaces rather than a silent conversion (this
-    ///   crate carries no pixel-conversion dependency). The common zen codecs
-    ///   decode to and encode from sRGB `RGBA8` / `RGB8`, so those pairs bridge;
-    ///   a decoder whose only outputs are disjoint from the target's inputs
-    ///   errors instead of corrupting.
+    ///   so decoder and encoder meet without any pixel conversion (this crate
+    ///   carries no conversion dependency). It errors — rather than corrupting —
+    ///   only when the two supported sets are disjoint (e.g. a RAW decoder that
+    ///   emits 16-bit / f32-linear only, into an encoder that accepts 8-bit
+    ///   only) or when a decoder ignores the preference and emits a native
+    ///   descriptor the encoder rejects. Since every common raster codec both
+    ///   decodes to and encodes from sRGB `RGB8` / `RGBA8`, those pairs bridge.
     ///
     /// Errors with [`NoDecoder`](CodecSetError::NoDecoder) when `input`'s
     /// detected format has no registered decoder, [`NoEncoder`](CodecSetError::NoEncoder)
@@ -543,7 +545,14 @@ impl CodecSet {
         metadata: MetadataPolicy,
         color: ColorEmitPolicy,
     ) -> Result<EncodeOutput, CodecSetError> {
-        let decoded = self.decode(input)?;
+        // Ask the decoder to emit a descriptor the target encoder accepts, so
+        // the two meet on a shared pixel format with no adaptation. A decoder
+        // that can't honor the preference falls back to its native format.
+        let target_inputs = self
+            .encoder_for(target)
+            .ok_or(CodecSetError::NoEncoder(target))?
+            .supported_descriptors();
+        let decoded = self.decode_preferring(input, target_inputs)?;
         let source_metadata = Metadata::from(decoded.info());
         let mut job = self.encode_job_with(target, fidelity)?;
         job.set_metadata_policy(source_metadata, metadata);

--- a/src/set.rs
+++ b/src/set.rs
@@ -3,8 +3,8 @@
 //! A [`CodecSet`] holds any number of decoder and encoder configs behind the
 //! object-safe [`DynDecoderConfig`] / [`DynEncoderConfig`] traits and gives
 //! them one entry point per operation: detect-and-decode, probe, push decode,
-//! animation decode, and format-keyed encode. Registration is one line per
-//! codec — each config announces its own formats
+//! animation decode, format-keyed encode, and resource estimation.
+//! Registration is one line per codec — each config announces its own formats
 //! ([`DecoderConfig::formats()`] / [`EncoderConfig::format()`]), so the set
 //! needs no per-codec wiring.
 //!
@@ -63,6 +63,7 @@ use core::fmt;
 
 use zenpixels::{PixelDescriptor, PixelSlice};
 
+use crate::estimate::{ComputeEnvironment, ImageCharacteristics, ResourceEstimate};
 use crate::fidelity::Fidelity;
 use crate::format::{ImageFormat, ImageFormatRegistry};
 use crate::traits::{
@@ -500,6 +501,60 @@ impl CodecSet {
             .ok_or(CodecSetError::NoEncoder(format))?;
         let tuned = entry.clone_entry().with_fidelity_entry(fidelity);
         Ok(self.stamped_encode_job(tuned.as_dyn()))
+    }
+
+    // --- Resource estimation ------------------------------------------------
+
+    /// Predict the peak memory and wall-time of **encoding** an image with the
+    /// given [`ImageCharacteristics`] as `format` on `compute`, without
+    /// encoding anything.
+    ///
+    /// Forwards to the registered encoder's
+    /// [`estimate_encode_resources`](DynEncoderConfig::estimate_encode_resources).
+    /// A codec without a calibrated cost model returns
+    /// [`ResourceEstimate::unknown`] (every field `None`) rather than failing;
+    /// the call errors only with [`NoEncoder`](CodecSetError::NoEncoder) when no
+    /// encoder for `format` is registered.
+    ///
+    /// Unlike [`probe`](Self::probe), this takes explicit characteristics
+    /// instead of input bytes: an encode has no input image yet, so the caller
+    /// describes the pixels it is about to hand the encoder.
+    pub fn estimate_encode(
+        &self,
+        format: ImageFormat,
+        image: &ImageCharacteristics,
+        compute: &ComputeEnvironment,
+    ) -> Result<ResourceEstimate, CodecSetError> {
+        Ok(self
+            .encoder_for(format)
+            .ok_or(CodecSetError::NoEncoder(format))?
+            .estimate_encode_resources(image, compute))
+    }
+
+    /// Predict the peak memory and wall-time of **decoding** an image with the
+    /// given [`ImageCharacteristics`] as `format` on `compute`, without
+    /// decoding anything.
+    ///
+    /// Forwards to the registered decoder's
+    /// [`estimate_decode_resources`](DynDecoderConfig::estimate_decode_resources).
+    /// A codec without a calibrated cost model returns
+    /// [`ResourceEstimate::unknown`]; the call errors only with
+    /// [`NoDecoder`](CodecSetError::NoDecoder) when no decoder for `format` is
+    /// registered.
+    ///
+    /// To estimate straight from encoded bytes, pair with [`probe`](Self::probe):
+    /// probe for the real dimensions and pixel format, build
+    /// [`ImageCharacteristics`] from them, then call this.
+    pub fn estimate_decode(
+        &self,
+        format: ImageFormat,
+        image: &ImageCharacteristics,
+        compute: &ComputeEnvironment,
+    ) -> Result<ResourceEstimate, CodecSetError> {
+        Ok(self
+            .decoder_for(format)
+            .ok_or(CodecSetError::NoDecoder(format))?
+            .estimate_decode_resources(image, compute))
     }
 
     // --- Internals ----------------------------------------------------------

--- a/src/set.rs
+++ b/src/set.rs
@@ -521,17 +521,22 @@ impl CodecSet {
     ///   [`animation_decoder`](Self::animation_decoder) + [`encode_job`](Self::encode_job).
     /// - **No pixel processing** — recompresses at the decoded dimensions and
     ///   pixel format; no resize, crop, or CMS conversion.
-    /// - **Meets on a shared pixel format, no adaptation** — the decoder is
-    ///   asked (via [`decode_preferring`](Self::decode_preferring)) to emit a
-    ///   [`PixelDescriptor`] the `target` encoder lists in
-    ///   [`supported_descriptors`](crate::traits::EncoderConfig::supported_descriptors),
-    ///   so decoder and encoder meet without any pixel conversion (this crate
-    ///   carries no conversion dependency). It errors — rather than corrupting —
-    ///   only when the two supported sets are disjoint (e.g. a RAW decoder that
-    ///   emits 16-bit / f32-linear only, into an encoder that accepts 8-bit
-    ///   only) or when a decoder ignores the preference and emits a native
-    ///   descriptor the encoder rejects. Since every common raster codec both
-    ///   decodes to and encodes from sRGB `RGB8` / `RGBA8`, those pairs bridge.
+    /// - **Precision-preserving, no adaptation** — it decodes at the source's
+    ///   native descriptor first and, when the `target` encoder accepts that
+    ///   descriptor (per its
+    ///   [`supported_descriptors`](crate::traits::EncoderConfig::supported_descriptors)),
+    ///   encodes it verbatim — so a 16-bit or HDR source is **not** flattened to
+    ///   8-bit when the target can carry it. Only when the native descriptor is
+    ///   unsupported does it re-decode (via
+    ///   [`decode_preferring`](Self::decode_preferring)) asking the decoder to
+    ///   bridge to a descriptor the encoder accepts: a second decode, and a
+    ///   precision drop only where the target genuinely can't hold the source's
+    ///   format (this crate carries no pixel-conversion dependency). It errors —
+    ///   rather than corrupting — only when the decoder and encoder supported
+    ///   sets are disjoint (e.g. a RAW decoder that emits 16-bit / f32-linear
+    ///   only, into an encoder that accepts 8-bit only). Since every common
+    ///   raster codec both decodes to and encodes from sRGB `RGB8` / `RGBA8`,
+    ///   those pairs bridge.
     ///
     /// Errors with [`NoDecoder`](CodecSetError::NoDecoder) when `input`'s
     /// detected format has no registered decoder, [`NoEncoder`](CodecSetError::NoEncoder)
@@ -545,14 +550,24 @@ impl CodecSet {
         metadata: MetadataPolicy,
         color: ColorEmitPolicy,
     ) -> Result<EncodeOutput, CodecSetError> {
-        // Ask the decoder to emit a descriptor the target encoder accepts, so
-        // the two meet on a shared pixel format with no adaptation. A decoder
-        // that can't honor the preference falls back to its native format.
         let target_inputs = self
             .encoder_for(target)
             .ok_or(CodecSetError::NoEncoder(target))?
             .supported_descriptors();
-        let decoded = self.decode_preferring(input, target_inputs)?;
+        // Decode at the source's native precision first. If the target encoder
+        // accepts that descriptor, encode it verbatim — a 16-bit / HDR source is
+        // not thrown down to 8-bit when the target can hold it. Only when the
+        // native descriptor is unsupported do we re-decode asking the decoder to
+        // bridge to a descriptor the encoder takes (a second decode; loses
+        // precision only where the target can't carry the source's format). The
+        // encoders list 8-bit descriptors first, so preferring that list up
+        // front would otherwise flatten every multi-depth source to 8-bit.
+        let decoded = self.decode(input)?;
+        let decoded = if target_inputs.contains(&decoded.pixels().descriptor()) {
+            decoded
+        } else {
+            self.decode_preferring(input, target_inputs)?
+        };
         let source_metadata = Metadata::from(decoded.info());
         let mut job = self.encode_job_with(target, fidelity)?;
         job.set_metadata_policy(source_metadata, metadata);

--- a/src/set.rs
+++ b/src/set.rs
@@ -72,8 +72,8 @@ use crate::traits::{
     EncoderConfig,
 };
 use crate::{
-    DecodeOutput, DecodePolicy, DecodeRowSink, EncodeOutput, EncodePolicy, ImageInfo, OutputInfo,
-    ResourceLimits, StopToken,
+    ColorEmitPolicy, DecodeOutput, DecodePolicy, DecodeRowSink, EncodeOutput, EncodePolicy,
+    ImageInfo, Metadata, MetadataPolicy, OutputInfo, ResourceLimits, StopToken,
 };
 
 // ===========================================================================
@@ -498,6 +498,61 @@ impl CodecSet {
             .ok_or(CodecSetError::NoEncoder(format))?;
         let tuned = entry.clone_entry().with_fidelity_entry(fidelity);
         Ok(self.stamped_encode_job(tuned.as_dyn()))
+    }
+
+    /// Decode `input` and re-encode it to `target` at `fidelity` — the one-call
+    /// recompress / reformat, carrying the source's metadata under an explicit
+    /// retention policy and applying a color-emission policy.
+    ///
+    /// The headline proxy operation: `decode → carry source metadata → encode`.
+    /// The source's ICC / EXIF / XMP / CICP / HDR / orientation are read off the
+    /// decode result and re-embedded, filtered by `metadata`
+    /// ([`Web`](MetadataPolicy::Web) strips GPS / camera / timestamps / XMP and
+    /// keeps orientation + rights + color; [`PreserveExact`](MetadataPolicy::PreserveExact)
+    /// carries everything verbatim). `color` ([`ColorEmitPolicy`]) governs how
+    /// color *signaling* (ICC vs CICP) is emitted — it is **not** a pixel-level
+    /// color-space conversion. The color policy merges onto the set-level
+    /// [`EncodePolicy`] (overriding only its color field).
+    ///
+    /// # Scope and failure modes
+    ///
+    /// - **Single image** — decodes the first frame only, like
+    ///   [`decode`](Self::decode); for animation use
+    ///   [`animation_decoder`](Self::animation_decoder) + [`encode_job`](Self::encode_job).
+    /// - **No pixel processing** — recompresses at the decoded dimensions and
+    ///   pixel format; no resize, crop, or CMS conversion.
+    /// - **No descriptor adaptation** — the decoder's output pixels go straight
+    ///   to the encoder. If the decoder emits a [`PixelDescriptor`] the `target`
+    ///   encoder does not list in
+    ///   [`supported_descriptors`](crate::traits::EncoderConfig::supported_descriptors),
+    ///   the encoder's error surfaces rather than a silent conversion (this
+    ///   crate carries no pixel-conversion dependency). The common zen codecs
+    ///   decode to and encode from sRGB `RGBA8` / `RGB8`, so those pairs bridge;
+    ///   a decoder whose only outputs are disjoint from the target's inputs
+    ///   errors instead of corrupting.
+    ///
+    /// Errors with [`NoDecoder`](CodecSetError::NoDecoder) when `input`'s
+    /// detected format has no registered decoder, [`NoEncoder`](CodecSetError::NoEncoder)
+    /// when `target` has no registered encoder, and forwards any decode or
+    /// encode error.
+    pub fn transcode(
+        &self,
+        input: &[u8],
+        target: ImageFormat,
+        fidelity: Fidelity,
+        metadata: MetadataPolicy,
+        color: ColorEmitPolicy,
+    ) -> Result<EncodeOutput, CodecSetError> {
+        let decoded = self.decode(input)?;
+        let source_metadata = Metadata::from(decoded.info());
+        let mut job = self.encode_job_with(target, fidelity)?;
+        job.set_metadata_policy(source_metadata, metadata);
+        job.set_policy(
+            self.encode_policy
+                .unwrap_or_else(EncodePolicy::none)
+                .with_color(color),
+        );
+        Ok(job.encode(decoded.pixels())?)
     }
 
     // --- Resource estimation ------------------------------------------------

--- a/src/set.rs
+++ b/src/set.rs
@@ -455,7 +455,7 @@ impl CodecSet {
         format: ImageFormat,
         pixels: PixelSlice<'_>,
     ) -> Result<EncodeOutput, CodecSetError> {
-        Ok(self.encode_job(format)?.into_encoder()?.encode(pixels)?)
+        Ok(self.encode_job(format)?.encode(pixels)?)
     }
 
     /// Encode `pixels` to `format` at a per-call [`Fidelity`], overriding the
@@ -469,10 +469,7 @@ impl CodecSet {
         fidelity: Fidelity,
         pixels: PixelSlice<'_>,
     ) -> Result<EncodeOutput, CodecSetError> {
-        Ok(self
-            .encode_job_with(format, fidelity)?
-            .into_encoder()?
-            .encode(pixels)?)
+        Ok(self.encode_job_with(format, fidelity)?.encode(pixels)?)
     }
 
     /// An encode job for `format` with this set's defaults stamped on.

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,0 +1,640 @@
+//! Multi-codec registry: build a [`CodecSet`] once, share it everywhere.
+//!
+//! A [`CodecSet`] holds any number of decoder and encoder configs behind the
+//! object-safe [`DynDecoderConfig`] / [`DynEncoderConfig`] traits and gives
+//! them one entry point per operation: detect-and-decode, probe, push decode,
+//! animation decode, and format-keyed encode. Registration is one line per
+//! codec — each config announces its own formats
+//! ([`DecoderConfig::formats()`] / [`EncoderConfig::format()`]), so the set
+//! needs no per-codec wiring.
+//!
+//! ```rust,ignore
+//! use zencodec::{CodecSet, ImageFormat};
+//!
+//! let codecs = CodecSet::new()
+//!     .with_decoder(zenjpeg::JpegDecoderConfig::new())
+//!     .with_decoder(zenpng::PngDecoderConfig::new())
+//!     .with_encoder(zenjpeg::JpegEncoderConfig::new().with_generic_quality(85.0));
+//!
+//! let image = codecs.decode(&bytes)?;                          // detect → decode
+//! let jpeg = codecs.encode(ImageFormat::Jpeg, image.pixels())?; // format-keyed
+//! ```
+//!
+//! # Sharing one set app-wide
+//!
+//! [`CodecSet`] is `Send + Sync + 'static` and every operation takes `&self`,
+//! so build it once and share it for the life of the process — behind a
+//! `std::sync::LazyLock` / `OnceLock` static, an `Arc`, or (in `no_std`) a
+//! `Box::leak`'d `&'static CodecSet`:
+//!
+//! ```rust,ignore
+//! use std::sync::LazyLock;
+//! use zencodec::CodecSet;
+//!
+//! static CODECS: LazyLock<CodecSet> = LazyLock::new(|| {
+//!     CodecSet::new()
+//!         .with_decoder(zenjpeg::JpegDecoderConfig::new())
+//!         .with_encoder(zenjpeg::JpegEncoderConfig::new())
+//! });
+//!
+//! let image = CODECS.decode(&bytes)?; // any thread, no locking
+//! ```
+//!
+//! Registered encoder configs act as *templates*: codec-specific options are
+//! set on the concrete config before registration, and per-call fidelity goes
+//! through [`CodecSet::encode_with`], which clones the template internally.
+//! [`CodecSet`] is also [`Clone`], so a shared base set can be extended per
+//! tenant or per request.
+//!
+//! # Format detection
+//!
+//! [`CodecSet::detect`] consults only the formats that have a registered
+//! decoder, in the priority order of
+//! [`ImageFormatRegistry::common()`](crate::ImageFormatRegistry::common)
+//! (which resolves ambiguous ISOBMFF containers — AVIF before HEIC — and DNG
+//! before TIFF), followed by any [`ImageFormat::Custom`] formats in
+//! registration order. Registration order therefore cannot break the curated
+//! magic-byte priority.
+
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::fmt;
+
+use zenpixels::{PixelDescriptor, PixelSlice};
+
+use crate::fidelity::Fidelity;
+use crate::format::{ImageFormat, ImageFormatRegistry};
+use crate::traits::{
+    AnimationFrameEncoder, BoxedError, DecoderConfig, DynAnimationFrameDecoder, DynDecodeJob,
+    DynDecoderConfig, DynEncodeJob, DynEncoderConfig, DynStreamingDecoder, EncodeJob, Encoder,
+    EncoderConfig,
+};
+use crate::{
+    DecodeOutput, DecodePolicy, DecodeRowSink, EncodeOutput, EncodePolicy, ImageInfo, OutputInfo,
+    ResourceLimits, StopToken,
+};
+
+// ===========================================================================
+// Internal entries — object-safe configs that can also clone themselves
+// ===========================================================================
+//
+// `DynDecoderConfig` / `DynEncoderConfig` are deliberately left untouched
+// (adding a required method would break any manual implementor). The set
+// instead captures clone/fidelity capability at registration time, where the
+// concrete type — and its `Clone` bound from `DecoderConfig`/`EncoderConfig`
+// — is still known.
+
+trait DecoderEntry: DynDecoderConfig {
+    fn clone_entry(&self) -> Box<dyn DecoderEntry>;
+    fn as_dyn(&self) -> &dyn DynDecoderConfig;
+}
+
+impl<C> DecoderEntry for C
+where
+    C: DecoderConfig + 'static,
+{
+    fn clone_entry(&self) -> Box<dyn DecoderEntry> {
+        Box::new(self.clone())
+    }
+    fn as_dyn(&self) -> &dyn DynDecoderConfig {
+        self
+    }
+}
+
+trait EncoderEntry: DynEncoderConfig {
+    fn clone_entry(&self) -> Box<dyn EncoderEntry>;
+    fn with_fidelity_entry(self: Box<Self>, fidelity: Fidelity) -> Box<dyn EncoderEntry>;
+    fn as_dyn(&self) -> &dyn DynEncoderConfig;
+}
+
+impl<C> EncoderEntry for C
+where
+    C: EncoderConfig + 'static,
+    <C::Job as EncodeJob>::Enc: Encoder + Send,
+    <C::Job as EncodeJob>::AnimationFrameEnc: AnimationFrameEncoder,
+{
+    fn clone_entry(&self) -> Box<dyn EncoderEntry> {
+        Box::new(self.clone())
+    }
+    fn with_fidelity_entry(self: Box<Self>, fidelity: Fidelity) -> Box<dyn EncoderEntry> {
+        Box::new((*self).with_fidelity(fidelity))
+    }
+    fn as_dyn(&self) -> &dyn DynEncoderConfig {
+        self
+    }
+}
+
+// ===========================================================================
+// CodecSetError
+// ===========================================================================
+
+/// Errors from [`CodecSet`] operations.
+///
+/// The set-level failures ([`UnrecognizedFormat`](CodecSetError::UnrecognizedFormat),
+/// [`NoDecoder`](CodecSetError::NoDecoder), [`NoEncoder`](CodecSetError::NoEncoder))
+/// are matchable directly; a failure inside the selected codec is passed
+/// through as [`Codec`](CodecSetError::Codec), whose
+/// [`source()`](core::error::Error::source) chain exposes the codec's own
+/// error (inspect it with [`CodecErrorExt`](crate::CodecErrorExt) /
+/// [`find_cause`](crate::find_cause)).
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum CodecSetError {
+    /// No registered decoder's format matched the input's magic bytes.
+    UnrecognizedFormat,
+    /// The format is known, but no decoder for it is registered in this set.
+    NoDecoder(ImageFormat),
+    /// No encoder for the requested format is registered in this set.
+    NoEncoder(ImageFormat),
+    /// The selected codec failed.
+    Codec(BoxedError),
+}
+
+impl fmt::Display for CodecSetError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnrecognizedFormat => {
+                f.write_str("no registered decoder's format matched the input bytes")
+            }
+            Self::NoDecoder(fmt_) => write!(f, "no decoder registered for {fmt_}"),
+            Self::NoEncoder(fmt_) => write!(f, "no encoder registered for {fmt_}"),
+            Self::Codec(e) => write!(f, "codec error: {e}"),
+        }
+    }
+}
+
+impl core::error::Error for CodecSetError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Codec(e) => Some(&**e),
+            _ => None,
+        }
+    }
+}
+
+impl From<BoxedError> for CodecSetError {
+    fn from(e: BoxedError) -> Self {
+        Self::Codec(e)
+    }
+}
+
+// ===========================================================================
+// CodecSet
+// ===========================================================================
+
+/// A runtime set of codecs with one entry point per operation.
+///
+/// See the [module docs](self) for the registration model, detection
+/// semantics, and the app-wide sharing pattern.
+///
+/// Operation defaults ([`with_limits`](Self::with_limits),
+/// [`with_stop`](Self::with_stop), [`with_decode_policy`](Self::with_decode_policy),
+/// [`with_encode_policy`](Self::with_encode_policy)) are stamped onto every
+/// job the set creates. Per-operation control (decode hints, metadata,
+/// canvas/loop settings) is available through [`decode_job`](Self::decode_job)
+/// / [`encode_job`](Self::encode_job), which return the stamped job for
+/// further configuration.
+pub struct CodecSet {
+    decoders: Vec<Box<dyn DecoderEntry>>,
+    encoders: Vec<Box<dyn EncoderEntry>>,
+    limits: Option<ResourceLimits>,
+    stop: Option<StopToken>,
+    decode_policy: Option<DecodePolicy>,
+    encode_policy: Option<EncodePolicy>,
+}
+
+impl CodecSet {
+    /// An empty set. Register codecs with [`with_decoder`](Self::with_decoder)
+    /// and [`with_encoder`](Self::with_encoder).
+    pub fn new() -> Self {
+        Self {
+            decoders: Vec::new(),
+            encoders: Vec::new(),
+            limits: None,
+            stop: None,
+            decode_policy: None,
+            encode_policy: None,
+        }
+    }
+
+    // --- Registration -----------------------------------------------------
+
+    /// Register a decoder config. It serves every format in its
+    /// [`DecoderConfig::formats()`] list.
+    ///
+    /// If several registered decoders claim the same format, the first
+    /// registered wins.
+    pub fn with_decoder(mut self, config: impl DecoderConfig + 'static) -> Self {
+        self.decoders.push(Box::new(config));
+        self
+    }
+
+    /// Register an encoder config for its [`EncoderConfig::format()`].
+    ///
+    /// The config is a *template*: codec-specific options are set on the
+    /// concrete type before registration; per-call fidelity goes through
+    /// [`encode_with`](Self::encode_with). If several registered encoders
+    /// claim the same format, the first registered wins.
+    pub fn with_encoder<C>(mut self, config: C) -> Self
+    where
+        C: EncoderConfig + 'static,
+        <C::Job as EncodeJob>::Enc: Encoder + Send,
+        <C::Job as EncodeJob>::AnimationFrameEnc: AnimationFrameEncoder,
+    {
+        self.encoders.push(Box::new(config));
+        self
+    }
+
+    // --- Operation defaults -------------------------------------------------
+
+    /// Resource limits stamped onto every job this set creates.
+    pub fn with_limits(mut self, limits: ResourceLimits) -> Self {
+        self.limits = Some(limits);
+        self
+    }
+
+    /// Cooperative-cancellation token stamped onto every job this set creates.
+    pub fn with_stop(mut self, stop: StopToken) -> Self {
+        self.stop = Some(stop);
+        self
+    }
+
+    /// Decode security policy stamped onto every decode job this set creates.
+    pub fn with_decode_policy(mut self, policy: DecodePolicy) -> Self {
+        self.decode_policy = Some(policy);
+        self
+    }
+
+    /// Encode policy stamped onto every encode job this set creates.
+    pub fn with_encode_policy(mut self, policy: EncodePolicy) -> Self {
+        self.encode_policy = Some(policy);
+        self
+    }
+
+    // --- Queries ------------------------------------------------------------
+
+    /// Whether a decoder for `format` is registered.
+    pub fn can_decode(&self, format: ImageFormat) -> bool {
+        self.decoder_entry(format).is_some()
+    }
+
+    /// Whether an encoder for `format` is registered.
+    pub fn can_encode(&self, format: ImageFormat) -> bool {
+        self.encoder_entry(format).is_some()
+    }
+
+    /// The registered decoder config for `format`, if any.
+    pub fn decoder_for(&self, format: ImageFormat) -> Option<&dyn DynDecoderConfig> {
+        self.decoder_entry(format).map(|e| e.as_dyn())
+    }
+
+    /// The registered encoder config for `format`, if any.
+    pub fn encoder_for(&self, format: ImageFormat) -> Option<&dyn DynEncoderConfig> {
+        self.encoder_entry(format).map(|e| e.as_dyn())
+    }
+
+    /// Formats with a registered decoder, in registration order.
+    ///
+    /// May repeat a format if several decoders claim it.
+    pub fn decodable_formats(&self) -> impl Iterator<Item = ImageFormat> + '_ {
+        self.decoders
+            .iter()
+            .flat_map(|d| d.formats().iter().copied())
+    }
+
+    /// Formats with a registered encoder, in registration order.
+    pub fn encodable_formats(&self) -> impl Iterator<Item = ImageFormat> + '_ {
+        self.encoders.iter().map(|e| e.format())
+    }
+
+    /// Detect the input's format from magic bytes, consulting only formats
+    /// with a registered decoder.
+    ///
+    /// Built-in formats are checked in the curated priority order of
+    /// [`ImageFormatRegistry::common()`](ImageFormatRegistry::common), then
+    /// [`ImageFormat::Custom`] formats from registered decoders in
+    /// registration order. Fetch at least
+    /// [`ImageFormat::RECOMMENDED_PROBE_BYTES`] for reliable detection.
+    pub fn detect(&self, data: &[u8]) -> Option<ImageFormat> {
+        for def in ImageFormatRegistry::common().formats() {
+            let format = def.to_image_format();
+            if self.can_decode(format) && (def.detect)(data) {
+                return Some(format);
+            }
+        }
+        for decoder in &self.decoders {
+            for &format in decoder.formats() {
+                if let ImageFormat::Custom(def) = format
+                    && (def.detect)(data)
+                {
+                    return Some(format);
+                }
+            }
+        }
+        None
+    }
+
+    // --- Decode -------------------------------------------------------------
+
+    /// Probe image metadata (header parse only) after detecting the format.
+    pub fn probe<'a>(&'a self, data: &'a [u8]) -> Result<ImageInfo, CodecSetError> {
+        let format = self.detect(data).ok_or(CodecSetError::UnrecognizedFormat)?;
+        Ok(self.decode_job(format)?.probe(data)?)
+    }
+
+    /// Detect the format and decode to owned pixels in the decoder's native
+    /// pixel format.
+    pub fn decode<'a>(&'a self, data: &'a [u8]) -> Result<DecodeOutput, CodecSetError> {
+        self.decode_preferring(data, &[])
+    }
+
+    /// Detect the format and decode, requesting output in one of the
+    /// `preferred` pixel formats (ranked; the decoder picks the first it can
+    /// produce without lossy conversion, else its native format).
+    pub fn decode_preferring<'a>(
+        &'a self,
+        data: &'a [u8],
+        preferred: &[PixelDescriptor],
+    ) -> Result<DecodeOutput, CodecSetError> {
+        let format = self.detect(data).ok_or(CodecSetError::UnrecognizedFormat)?;
+        self.decode_as(format, data, preferred)
+    }
+
+    /// Decode `data` as `format`, skipping detection.
+    pub fn decode_as<'a>(
+        &'a self,
+        format: ImageFormat,
+        data: &'a [u8],
+        preferred: &[PixelDescriptor],
+    ) -> Result<DecodeOutput, CodecSetError> {
+        Ok(self
+            .decode_job(format)?
+            .into_decoder(Cow::Borrowed(data), preferred)?
+            .decode()?)
+    }
+
+    /// Detect the format and decode into a caller-owned sink (push model, the
+    /// most memory-efficient path).
+    pub fn push_decode<'a>(
+        &'a self,
+        data: &'a [u8],
+        sink: &mut dyn DecodeRowSink,
+        preferred: &[PixelDescriptor],
+    ) -> Result<OutputInfo, CodecSetError> {
+        let format = self.detect(data).ok_or(CodecSetError::UnrecognizedFormat)?;
+        Ok(self
+            .decode_job(format)?
+            .push_decode(Cow::Borrowed(data), sink, preferred)?)
+    }
+
+    /// Detect the format and create a full-frame animation decoder.
+    ///
+    /// The returned decoder owns its data (`'static`) and outlives both the
+    /// set borrow and `data`.
+    pub fn animation_decoder<'a>(
+        &'a self,
+        data: &'a [u8],
+        preferred: &[PixelDescriptor],
+    ) -> Result<Box<dyn DynAnimationFrameDecoder>, CodecSetError> {
+        let format = self.detect(data).ok_or(CodecSetError::UnrecognizedFormat)?;
+        Ok(self
+            .decode_job(format)?
+            .into_animation_frame_decoder(Cow::Borrowed(data), preferred)?)
+    }
+
+    /// Detect the format and create a pull-streaming decoder that yields
+    /// scanline batches.
+    ///
+    /// The returned decoder borrows this set (and `data`); a set stored in a
+    /// `static` therefore yields a `'static` decoder from `'static` data. Not
+    /// every codec supports pull streaming — those return an error (use
+    /// [`push_decode`](Self::push_decode) instead).
+    pub fn streaming_decoder<'a>(
+        &'a self,
+        data: &'a [u8],
+        preferred: &[PixelDescriptor],
+    ) -> Result<Box<dyn DynStreamingDecoder + 'a>, CodecSetError> {
+        let format = self.detect(data).ok_or(CodecSetError::UnrecognizedFormat)?;
+        Ok(self
+            .decode_job(format)?
+            .into_streaming_decoder(Cow::Borrowed(data), preferred)?)
+    }
+
+    /// A decode job for `format` with this set's defaults stamped on.
+    ///
+    /// The escape hatch behind every decode convenience: set decode hints
+    /// (crop, orientation, gain map, start frame) on the job, then call one of
+    /// its `into_*` executors or [`probe`](DynDecodeJob::probe).
+    pub fn decode_job<'a>(
+        &'a self,
+        format: ImageFormat,
+    ) -> Result<Box<dyn DynDecodeJob<'a> + 'a>, CodecSetError> {
+        let entry = self
+            .decoder_entry(format)
+            .ok_or(CodecSetError::NoDecoder(format))?;
+        let mut job = entry.dyn_job();
+        if let Some(limits) = self.limits {
+            job.set_limits(limits);
+        }
+        if let Some(stop) = &self.stop {
+            job.set_stop(stop.clone());
+        }
+        if let Some(policy) = self.decode_policy {
+            job.set_policy(policy);
+        }
+        Ok(job)
+    }
+
+    // --- Encode -------------------------------------------------------------
+
+    /// Encode `pixels` to `format` using the registered encoder template.
+    pub fn encode(
+        &self,
+        format: ImageFormat,
+        pixels: PixelSlice<'_>,
+    ) -> Result<EncodeOutput, CodecSetError> {
+        Ok(self.encode_job(format)?.into_encoder()?.encode(pixels)?)
+    }
+
+    /// Encode `pixels` to `format` at a per-call [`Fidelity`], overriding the
+    /// template's quality/lossless setting.
+    ///
+    /// Clones the registered template internally; codec-specific options set
+    /// at registration are preserved.
+    pub fn encode_with(
+        &self,
+        format: ImageFormat,
+        fidelity: Fidelity,
+        pixels: PixelSlice<'_>,
+    ) -> Result<EncodeOutput, CodecSetError> {
+        Ok(self
+            .encode_job_with(format, fidelity)?
+            .into_encoder()?
+            .encode(pixels)?)
+    }
+
+    /// An encode job for `format` with this set's defaults stamped on.
+    ///
+    /// The escape hatch behind the encode conveniences: set metadata, canvas
+    /// size, or loop count on the job, then call
+    /// [`into_encoder`](DynEncodeJob::into_encoder) (one-shot or
+    /// `push_rows`/`finish` streaming) or
+    /// [`into_animation_frame_encoder`](DynEncodeJob::into_animation_frame_encoder).
+    pub fn encode_job(&self, format: ImageFormat) -> Result<Box<dyn DynEncodeJob>, CodecSetError> {
+        let entry = self
+            .encoder_entry(format)
+            .ok_or(CodecSetError::NoEncoder(format))?;
+        Ok(self.stamped_encode_job(entry.as_dyn()))
+    }
+
+    /// Like [`encode_job`](Self::encode_job), with a per-call [`Fidelity`]
+    /// applied to a clone of the template first.
+    pub fn encode_job_with(
+        &self,
+        format: ImageFormat,
+        fidelity: Fidelity,
+    ) -> Result<Box<dyn DynEncodeJob>, CodecSetError> {
+        let entry = self
+            .encoder_entry(format)
+            .ok_or(CodecSetError::NoEncoder(format))?;
+        let tuned = entry.clone_entry().with_fidelity_entry(fidelity);
+        Ok(self.stamped_encode_job(tuned.as_dyn()))
+    }
+
+    // --- Internals ----------------------------------------------------------
+
+    fn decoder_entry(&self, format: ImageFormat) -> Option<&dyn DecoderEntry> {
+        self.decoders
+            .iter()
+            .find(|d| d.formats().contains(&format))
+            .map(|b| &**b)
+    }
+
+    fn encoder_entry(&self, format: ImageFormat) -> Option<&dyn EncoderEntry> {
+        self.encoders
+            .iter()
+            .find(|e| e.format() == format)
+            .map(|b| &**b)
+    }
+
+    fn stamped_encode_job(&self, config: &dyn DynEncoderConfig) -> Box<dyn DynEncodeJob> {
+        let mut job = config.dyn_job();
+        if let Some(limits) = self.limits {
+            job.set_limits(limits);
+        }
+        if let Some(stop) = &self.stop {
+            job.set_stop(stop.clone());
+        }
+        if let Some(policy) = self.encode_policy {
+            job.set_policy(policy);
+        }
+        job
+    }
+}
+
+impl Default for CodecSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Clone for CodecSet {
+    fn clone(&self) -> Self {
+        Self {
+            decoders: self.decoders.iter().map(|d| d.clone_entry()).collect(),
+            encoders: self.encoders.iter().map(|e| e.clone_entry()).collect(),
+            limits: self.limits,
+            stop: self.stop.clone(),
+            decode_policy: self.decode_policy,
+            encode_policy: self.encode_policy,
+        }
+    }
+}
+
+impl fmt::Debug for CodecSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let decodable: Vec<ImageFormat> = self.decodable_formats().collect();
+        let encodable: Vec<ImageFormat> = self.encodable_formats().collect();
+        f.debug_struct("CodecSet")
+            .field("decodable", &decodable)
+            .field("encodable", &encodable)
+            .field("limits", &self.limits)
+            .finish_non_exhaustive()
+    }
+}
+
+// ===========================================================================
+// Tests (codec-free; end-to-end behavior tests live in zencodec-testkit)
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_send_sync_static<T: Send + Sync + 'static>() {}
+
+    #[test]
+    fn codec_set_is_send_sync_static() {
+        assert_send_sync_static::<CodecSet>();
+        assert_send_sync_static::<CodecSetError>();
+    }
+
+    #[test]
+    fn empty_set_detects_nothing() {
+        let set = CodecSet::new();
+        // Valid JPEG magic, but no decoder registered for it.
+        assert_eq!(set.detect(&[0xFF, 0xD8, 0xFF, 0xE0]), None);
+        assert!(!set.can_decode(ImageFormat::Jpeg));
+        assert!(!set.can_encode(ImageFormat::Jpeg));
+        assert_eq!(set.decodable_formats().count(), 0);
+        assert_eq!(set.encodable_formats().count(), 0);
+    }
+
+    #[test]
+    fn empty_set_decode_is_unrecognized() {
+        let set = CodecSet::new();
+        match set.decode(&[0xFF, 0xD8, 0xFF, 0xE0]) {
+            Err(CodecSetError::UnrecognizedFormat) => {}
+            other => panic!("expected UnrecognizedFormat, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_as_without_decoder_is_no_decoder() {
+        let set = CodecSet::new();
+        match set.decode_as(ImageFormat::Jpeg, &[0xFF, 0xD8], &[]) {
+            Err(CodecSetError::NoDecoder(ImageFormat::Jpeg)) => {}
+            other => panic!("expected NoDecoder(Jpeg), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn encode_without_encoder_is_no_encoder() {
+        let set = CodecSet::new();
+        let bytes = [0u8; 3];
+        let pixels =
+            PixelSlice::new(&bytes, 1, 1, 3, PixelDescriptor::RGB8_SRGB).expect("pixel slice");
+        match set.encode(ImageFormat::Png, pixels) {
+            Err(CodecSetError::NoEncoder(ImageFormat::Png)) => {}
+            other => panic!("expected NoEncoder(Png), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_set_clone_and_debug() {
+        let set = CodecSet::new()
+            .with_limits(ResourceLimits::default())
+            .clone();
+        let dbg = alloc::format!("{set:?}");
+        assert!(dbg.contains("CodecSet"));
+    }
+
+    #[test]
+    fn error_display_names_format() {
+        let msg = alloc::format!("{}", CodecSetError::NoDecoder(ImageFormat::Jpeg));
+        assert!(msg.contains("JPEG"), "{msg}");
+        let msg = alloc::format!("{}", CodecSetError::NoEncoder(ImageFormat::WebP));
+        assert!(msg.contains("WebP"), "{msg}");
+    }
+}

--- a/src/set.rs
+++ b/src/set.rs
@@ -557,6 +557,44 @@ impl CodecSet {
             .estimate_decode_resources(image, compute))
     }
 
+    /// Predict the peak memory and wall-time of **decoding** `data`, probing it
+    /// for the format and dimensions first — the bytes-based counterpart to
+    /// [`estimate_decode`](Self::estimate_decode), as convenient as
+    /// [`probe`](Self::probe).
+    ///
+    /// This detects and header-parses the input like [`probe`](Self::probe)
+    /// (same `UnrecognizedFormat` / codec errors), then estimates a still frame
+    /// at the probed canvas dimensions in the decoder's native output format —
+    /// its first
+    /// [`supported_descriptors`](DynDecoderConfig::supported_descriptors), which
+    /// carries the real channel count and bit depth (falling back to RGBA8 /
+    /// RGB8 from the probed alpha only if the decoder lists none). Animations
+    /// are costed as one canvas frame; for per-frame or full-sequence cost, or
+    /// a specific output pixel format, build [`ImageCharacteristics`] yourself
+    /// and call [`estimate_decode`](Self::estimate_decode).
+    pub fn estimate_decode_of(
+        &self,
+        data: &[u8],
+        compute: &ComputeEnvironment,
+    ) -> Result<ResourceEstimate, CodecSetError> {
+        // Key off the *detected* (registration) format, which is what
+        // `decoder_for` / `estimate_decode` index on — not `info.format`, the
+        // format the decoder *reports*, which can differ (e.g. a decoder
+        // registered under a custom format).
+        let format = self.detect(data).ok_or(CodecSetError::UnrecognizedFormat)?;
+        let info = self.decode_job(format)?.probe(data)?;
+        let descriptor = self
+            .decoder_for(format)
+            .and_then(|d| d.supported_descriptors().first().copied())
+            .unwrap_or(if info.has_alpha {
+                PixelDescriptor::RGBA8_SRGB
+            } else {
+                PixelDescriptor::RGB8_SRGB
+            });
+        let image = ImageCharacteristics::new(info.width, info.height, descriptor);
+        self.estimate_decode(format, &image, compute)
+    }
+
     // --- Internals ----------------------------------------------------------
 
     fn decoder_entry(&self, format: ImageFormat) -> Option<&dyn DecoderEntry> {

--- a/src/traits/decoding.rs
+++ b/src/traits/decoding.rs
@@ -6,7 +6,7 @@ use alloc::boxed::Box;
 use crate::estimate::{ComputeEnvironment, ImageCharacteristics, ResourceEstimate};
 use crate::format::ImageFormat;
 use crate::orientation::OrientationHint;
-use crate::{DecodeCapabilities, ImageInfo, OutputInfo, ResourceLimits, StopToken};
+use crate::{DecodeCapabilities, DecodeOutput, ImageInfo, OutputInfo, ResourceLimits, StopToken};
 use zenpixels::PixelDescriptor;
 
 use super::BoxedError;
@@ -82,6 +82,40 @@ pub trait DecoderConfig: Clone + Send + Sync {
     /// The job owns the config and all configuration set on it.
     /// The lifetime parameter is the data lifetime, inferred from usage.
     fn job<'a>(self) -> Self::Job<'a>;
+
+    /// One-shot convenience: decode `data` to owned pixels in the decoder's
+    /// native pixel format, with default job settings.
+    ///
+    /// Equivalent to `self.job().decoder(Cow::Borrowed(data), &[])?.decode()`.
+    /// For limits, cancellation, decode hints, or pixel-format preferences, go
+    /// through [`job()`](DecoderConfig::job).
+    ///
+    /// ```rust,ignore
+    /// let image = zenjpeg::JpegDecoderConfig::new().decode(&bytes)?;
+    /// ```
+    fn decode(self, data: &[u8]) -> Result<DecodeOutput, Self::Error>
+    where
+        Self: Sized,
+    {
+        self.job().decoder(Cow::Borrowed(data), &[])?.decode()
+    }
+
+    /// One-shot convenience: probe image metadata (header parse only, cheap)
+    /// with default job settings.
+    ///
+    /// Equivalent to `self.clone().job().probe(data)`. For limits or
+    /// cancellation context, go through [`job()`](DecoderConfig::job).
+    ///
+    /// ```rust,ignore
+    /// let info = zenjpeg::JpegDecoderConfig::new().probe(&bytes)?;
+    /// println!("{}x{}", info.width, info.height);
+    /// ```
+    fn probe(&self, data: &[u8]) -> Result<ImageInfo, Self::Error>
+    where
+        Self: Sized,
+    {
+        self.clone().job().probe(data)
+    }
 }
 
 // ===========================================================================

--- a/src/traits/dyn_encoding.rs
+++ b/src/traits/dyn_encoding.rs
@@ -257,6 +257,18 @@ pub trait DynEncodeJob {
     /// Mutable access to codec-specific extensions.
     fn extensions_mut(&mut self) -> Option<&mut dyn Any>;
 
+    /// One-shot: encode `pixels` with this job's configuration and return the
+    /// output — the common tail after `set_metadata_policy` / `set_limits` /
+    /// `set_policy`. Equivalent to `self.into_encoder()?.encode(pixels)`.
+    ///
+    /// Provided method (adding it broke no implementor). For streaming row-push
+    /// or animation, take the encoder yourself with
+    /// [`into_encoder`](Self::into_encoder) /
+    /// [`into_animation_frame_encoder`](Self::into_animation_frame_encoder).
+    fn encode(self: Box<Self>, pixels: PixelSlice<'_>) -> Result<EncodeOutput, BoxedError> {
+        self.into_encoder()?.encode(pixels)
+    }
+
     /// Create the single-image encoder (consumes this job).
     fn into_encoder(self: Box<Self>) -> Result<Box<dyn DynEncoder>, BoxedError>;
 

--- a/src/traits/encoding.rs
+++ b/src/traits/encoding.rs
@@ -447,6 +447,22 @@ pub trait EncodeJob: Sized {
     /// Create a one-shot encoder for a single image.
     fn encoder(self) -> Result<Self::Enc, Self::Error>;
 
+    /// One-shot: encode `pixels` with this job's configuration.
+    ///
+    /// The common tail after `with_metadata_policy` / `with_limits` /
+    /// `with_policy` — equivalent to `self.encoder()?.encode(pixels)`. This is
+    /// the job-level analog of [`EncoderConfig::encode`], which encodes with
+    /// *default* job settings; use this when you have configured the job first.
+    /// For streaming row-push or animation, take the encoder yourself with
+    /// [`encoder()`](Self::encoder) /
+    /// [`animation_frame_encoder()`](Self::animation_frame_encoder).
+    fn encode(self, pixels: PixelSlice<'_>) -> Result<EncodeOutput, Self::Error>
+    where
+        Self::Enc: Encoder<Error = Self::Error>,
+    {
+        self.encoder()?.encode(pixels)
+    }
+
     /// Create a full-frame animation encoder.
     ///
     /// Set loop count and canvas size before calling this.

--- a/src/traits/encoding.rs
+++ b/src/traits/encoding.rs
@@ -5,8 +5,8 @@ use alloc::boxed::Box;
 use crate::estimate::{ComputeEnvironment, ImageCharacteristics, ResourceEstimate};
 use crate::fidelity::{Fidelity, LossyTarget};
 use crate::format::ImageFormat;
-use crate::{EncodeCapabilities, Metadata, ResourceLimits, UnsupportedOperation};
-use zenpixels::PixelDescriptor;
+use crate::{EncodeCapabilities, EncodeOutput, Metadata, ResourceLimits, UnsupportedOperation};
+use zenpixels::{PixelDescriptor, PixelSlice};
 
 use super::BoxedError;
 use super::dyn_encoding::{AnimationFrameEncoderShim, DynAnimationFrameEncoder, DynEncoder};
@@ -204,6 +204,25 @@ pub trait EncoderConfig: Clone + Send + Sync {
     /// The job owns the config and all configuration set on it
     /// (stop token, limits, metadata).
     fn job(self) -> Self::Job;
+
+    /// One-shot convenience: encode `pixels` with default job settings.
+    ///
+    /// Equivalent to `self.job().encoder()?.encode(pixels)`. For metadata,
+    /// limits, cancellation, or streaming/animation encode, go through
+    /// [`job()`](EncoderConfig::job).
+    ///
+    /// ```rust,ignore
+    /// let out = zenjpeg::JpegEncoderConfig::new()
+    ///     .with_generic_quality(85.0)
+    ///     .encode(pixels)?;
+    /// ```
+    fn encode(self, pixels: PixelSlice<'_>) -> Result<EncodeOutput, Self::Error>
+    where
+        Self: Sized,
+        <Self::Job as EncodeJob>::Enc: Encoder<Error = Self::Error>,
+    {
+        self.job().encoder()?.encode(pixels)
+    }
 }
 
 // ===========================================================================

--- a/zencodec-testkit/Cargo.toml
+++ b/zencodec-testkit/Cargo.toml
@@ -13,7 +13,10 @@ include = ["/src/**", "/README.md", "/LICENSE*"]
 [dependencies]
 # Path for in-workspace development; version so a future `cargo publish` resolves
 # against crates.io. zencodec-testkit tracks zencodec's own version line.
-zencodec = { path = "..", version = "0.1.26" }
+# `std` so the reference codec (inherently std) and the usage examples can reach
+# `ComputeEnvironment::host()`; dev/test-only, never affects a no_std consumer's
+# own build.
+zencodec = { path = "..", version = "0.1.26", features = ["std"] }
 zenpixels = { version = "0.2.10", features = ["icc"] }
 enough = "0.4.4"
 # The `minimal` codec uses `type Error = At<CodecError>` (the envelope pattern),
@@ -24,3 +27,7 @@ whereat = "0.1.5"
 # For the decode-parallelism examples (tests/decode_parallelism.rs) — exercises
 # capping codec thread count via a sized rayon pool.
 rayon = "1.10.0"
+# For tests/usage.rs — the "caller also has zenpixels-convert" examples that
+# adapt a foreign pixel format into an encoder's supported set, and convert a
+# decoded buffer into a caller-chosen format.
+zenpixels-convert = "0.2.14"

--- a/zencodec-testkit/src/lib.rs
+++ b/zencodec-testkit/src/lib.rs
@@ -69,7 +69,9 @@ pub mod reference;
 
 #[cfg(test)]
 pub(crate) use minimal::{MinimalDecoderConfig, MinimalEncoderConfig};
-pub use reference::{RefError, ReferenceDecoderConfig, ReferenceEncoderConfig};
+pub use reference::{
+    RefError, ReferenceDecoderConfig, ReferenceEncoderConfig, ReferenceZcrDecoderConfig, ZCR_FORMAT,
+};
 
 // ===========================================================================
 // Result types

--- a/zencodec-testkit/src/reference.rs
+++ b/zencodec-testkit/src/reference.rs
@@ -35,8 +35,8 @@ use zencodec::encode::{
 };
 use zencodec::{
     AnimationFrame, CategorizedError, Cicp, CodecError, CodecIoKind, ErrorCategory, ImageFormat,
-    ImageInfo, ImageSequence, Metadata, Orientation, ResourceLimits, StopToken,
-    UnsupportedOperation,
+    ImageFormatDefinition, ImageInfo, ImageSequence, Metadata, Orientation, ResourceLimits,
+    StopToken, UnsupportedOperation,
 };
 use zenpixels::{PixelBuffer, PixelDescriptor, PixelSlice};
 
@@ -118,7 +118,7 @@ impl From<zencodec::LimitExceeded> for RefError {
 }
 
 /// The one-impl bridge a codec adds to return the shared envelope as
-/// `At<CodecError>` (the [`minimal`](crate::minimal) codec does this; the
+/// `At<CodecError>` (the internal `minimal` codec does this; the
 /// [`reference`](crate::reference) keeps the simpler `type Error = RefError`).
 ///
 /// `.start_at()` begins the location trace; `CodecError::of` then takes that
@@ -572,6 +572,65 @@ impl DecoderConfig for ReferenceDecoderConfig {
     }
     fn capabilities() -> &'static DecodeCapabilities {
         &DECODE_CAPS
+    }
+    fn job<'a>(self) -> Self::Job<'a> {
+        RefDecodeJob
+    }
+}
+
+fn detect_zcr(data: &[u8]) -> bool {
+    data.starts_with(MAGIC)
+}
+
+/// An [`ImageFormatDefinition`] whose `detect` matches the reference codec's
+/// `ZCR1` wire magic — the piece [`ReferenceDecoderConfig`] lacks.
+///
+/// The reference decoder registers under [`ImageFormat::Pnm`] (standing in for
+/// "a real codec"), but the bytes it produces are its own `ZCR1` container, not
+/// PNM — so [`CodecSet::detect`](zencodec::CodecSet::detect) can't route encoded
+/// reference bytes back to it. Register [`ReferenceZcrDecoderConfig`] under this
+/// format and detection-based decode (`decode` / `probe` / `estimate_decode_of`)
+/// works end to end, without every example hand-rolling its own custom format.
+pub static ZCR_FORMAT: ImageFormatDefinition = ImageFormatDefinition::new(
+    "zcr",
+    None,
+    "ZCR (reference codec wire format)",
+    "zcr",
+    &["zcr"],
+    "image/x-zcr",
+    &["image/x-zcr"],
+    true,  // alpha
+    true,  // animation
+    true,  // lossless
+    false, // lossy
+    MAGIC.len(),
+    detect_zcr,
+);
+
+static ZCR_FORMATS: &[ImageFormat] = &[ImageFormat::Custom(&ZCR_FORMAT)];
+
+/// The reference decoder registered under the self-detecting [`ZCR_FORMAT`]
+/// instead of [`ImageFormat::Pnm`].
+///
+/// Drop-in for [`ReferenceDecoderConfig`] on a [`CodecSet`](zencodec::CodecSet)
+/// when you want `set.decode(bytes)` / `set.probe(bytes)` to detect the
+/// reference codec's own bytes. Decode behavior is identical — only the
+/// registration format differs.
+#[derive(Clone, Debug, Default)]
+pub struct ReferenceZcrDecoderConfig;
+
+impl DecoderConfig for ReferenceZcrDecoderConfig {
+    type Error = RefError;
+    type Job<'a> = RefDecodeJob;
+
+    fn formats() -> &'static [ImageFormat] {
+        ZCR_FORMATS
+    }
+    fn supported_descriptors() -> &'static [PixelDescriptor] {
+        ReferenceDecoderConfig::supported_descriptors()
+    }
+    fn capabilities() -> &'static DecodeCapabilities {
+        ReferenceDecoderConfig::capabilities()
     }
     fn job<'a>(self) -> Self::Job<'a> {
         RefDecodeJob

--- a/zencodec-testkit/tests/codec_set.rs
+++ b/zencodec-testkit/tests/codec_set.rs
@@ -359,3 +359,43 @@ fn estimate_dispatches_to_the_registered_codec() {
         other => panic!("expected NoDecoder(Jpeg), got {other:?}"),
     }
 }
+
+#[test]
+fn estimate_decode_of_probes_then_estimates() {
+    // Zcr set so probe (detect + header parse) succeeds on the encoded bytes.
+    let set = CodecSet::new()
+        .with_decoder(ZcrDecoderConfig)
+        .with_encoder(ReferenceEncoderConfig::new());
+    let compute = ComputeEnvironment::new();
+
+    let encoded = set
+        .encode(ImageFormat::Pnm, rgb_pixels(&PIXELS, W, H))
+        .expect("encode");
+
+    // Bytes-based path == the explicit path built from the same probe, in the
+    // decoder's native output descriptor.
+    let est = set
+        .estimate_decode_of(encoded.data(), &compute)
+        .expect("estimate_decode_of");
+    // Mirror it explicitly: detected (registration) format + native descriptor.
+    let format = set.detect(encoded.data()).expect("detect");
+    let info = set.probe(encoded.data()).expect("probe");
+    let descriptor = set
+        .decoder_for(format)
+        .and_then(|d| d.supported_descriptors().first().copied())
+        .expect("native descriptor");
+    let explicit = set
+        .estimate_decode(
+            format,
+            &ImageCharacteristics::new(info.width, info.height, descriptor),
+            &compute,
+        )
+        .expect("estimate_decode");
+    assert_eq!(est, explicit);
+
+    // Unrecognized input → the same error probe() would raise.
+    match set.estimate_decode_of(b"not a known image at all", &compute) {
+        Err(CodecSetError::UnrecognizedFormat) => {}
+        other => panic!("expected UnrecognizedFormat, got {other:?}"),
+    }
+}

--- a/zencodec-testkit/tests/codec_set.rs
+++ b/zencodec-testkit/tests/codec_set.rs
@@ -9,6 +9,7 @@
 
 use std::sync::LazyLock;
 
+use zencodec::estimate::{ComputeEnvironment, ImageCharacteristics};
 use zencodec::prelude::*;
 use zencodec::{
     CodecSet, CodecSetError, ImageFormat, ImageFormatDefinition, Metadata, MetadataPolicy,
@@ -328,4 +329,33 @@ fn one_shot_trait_methods_work_directly() {
         .decode(out.data())
         .expect("one-shot decode");
     assert_eq!((decoded.width(), decoded.height()), (W, H));
+}
+
+#[test]
+fn estimate_dispatches_to_the_registered_codec() {
+    let set = reference_set();
+    let image = ImageCharacteristics::new(W, H, PixelDescriptor::RGB8_SRGB);
+    let compute = ComputeEnvironment::new();
+
+    // Registered format → forwards to the codec's estimator and succeeds
+    // (even when the codec reports `unknown()`).
+    assert!(
+        set.estimate_encode(ImageFormat::Pnm, &image, &compute)
+            .is_ok()
+    );
+    assert!(
+        set.estimate_decode(ImageFormat::Pnm, &image, &compute)
+            .is_ok()
+    );
+
+    // Unregistered format → typed error, mirroring encode/decode dispatch.
+    let decode_only = CodecSet::new().with_decoder(ReferenceDecoderConfig);
+    match decode_only.estimate_encode(ImageFormat::Pnm, &image, &compute) {
+        Err(CodecSetError::NoEncoder(ImageFormat::Pnm)) => {}
+        other => panic!("expected NoEncoder(Pnm), got {other:?}"),
+    }
+    match set.estimate_decode(ImageFormat::Jpeg, &image, &compute) {
+        Err(CodecSetError::NoDecoder(ImageFormat::Jpeg)) => {}
+        other => panic!("expected NoDecoder(Jpeg), got {other:?}"),
+    }
 }

--- a/zencodec-testkit/tests/codec_set.rs
+++ b/zencodec-testkit/tests/codec_set.rs
@@ -11,7 +11,9 @@ use std::sync::LazyLock;
 
 use zencodec::estimate::{ComputeEnvironment, ImageCharacteristics};
 use zencodec::prelude::*;
-use zencodec::{CodecSet, CodecSetError, ImageFormat, Metadata, MetadataPolicy, ResourceLimits};
+use zencodec::{
+    CodecSet, CodecSetError, ColorEmitPolicy, ImageFormat, Metadata, MetadataPolicy, ResourceLimits,
+};
 use zencodec_testkit::{
     ReferenceDecoderConfig, ReferenceEncoderConfig, ReferenceZcrDecoderConfig, ZCR_FORMAT,
 };
@@ -208,6 +210,52 @@ fn encode_job_carries_metadata() {
     assert_eq!(
         decoded.info().source_color.icc_profile.as_deref(),
         Some(&[1u8, 2, 3, 4][..])
+    );
+}
+
+#[test]
+fn transcode_roundtrips_pixels_and_carries_metadata() {
+    use zencodec::encode::Fidelity;
+
+    let set = CodecSet::new()
+        .with_decoder(ReferenceZcrDecoderConfig)
+        .with_encoder(ReferenceEncoderConfig::new());
+
+    // A source bitstream that carries an ICC profile.
+    let mut job = set.encode_job(ImageFormat::Pnm).expect("encode_job");
+    job.set_metadata_policy(
+        Metadata::none().with_icc(vec![9, 8, 7, 6]),
+        MetadataPolicy::PreserveExact,
+    );
+    let source = job
+        .encode(rgb_pixels(&PIXELS, W, H))
+        .expect("encode source");
+
+    // One call: decode → carry source metadata → re-encode.
+    let out = set
+        .transcode(
+            source.data(),
+            ImageFormat::Pnm,
+            Fidelity::Lossless,
+            MetadataPolicy::PreserveExact,
+            ColorEmitPolicy::Verbatim,
+        )
+        .expect("transcode");
+
+    // Pixels survive the round trip.
+    let decoded = set.decode(out.data()).expect("decode transcoded");
+    assert_eq!((decoded.width(), decoded.height()), (W, H));
+    let mut round = Vec::new();
+    let px = decoded.pixels();
+    for y in 0..px.rows() {
+        round.extend_from_slice(px.row(y));
+    }
+    assert_eq!(round, PIXELS);
+
+    // The ICC rode through under PreserveExact.
+    assert_eq!(
+        decoded.info().source_color.icc_profile.as_deref(),
+        Some(&[9u8, 8, 7, 6][..])
     );
 }
 

--- a/zencodec-testkit/tests/codec_set.rs
+++ b/zencodec-testkit/tests/codec_set.rs
@@ -1,0 +1,331 @@
+//! Behavior tests for `zencodec::CodecSet`, driven by the reference codec.
+//!
+//! The reference codec registers under `ImageFormat::Pnm` but uses its own
+//! `ZCR1` wire format, so magic-byte *detection* tests either use real PNM
+//! magic (detection only — the bytes aren't decodable) or the `Zcr` wrapper
+//! below, which re-registers the reference decoder under a custom
+//! `ImageFormatDefinition` whose `detect` matches the actual wire format —
+//! exercising the full detect → decode path end to end.
+
+use std::sync::LazyLock;
+
+use zencodec::prelude::*;
+use zencodec::{
+    CodecSet, CodecSetError, ImageFormat, ImageFormatDefinition, Metadata, MetadataPolicy,
+    ResourceLimits,
+};
+use zencodec_testkit::{RefError, ReferenceDecoderConfig, ReferenceEncoderConfig};
+use zenpixels::{PixelDescriptor, PixelSlice};
+
+// ===========================================================================
+// A custom-format registration of the reference decoder
+// ===========================================================================
+
+fn detect_zcr(data: &[u8]) -> bool {
+    data.len() >= 4 && &data[..4] == b"ZCR1"
+}
+
+static ZCR_FORMAT: ImageFormatDefinition = ImageFormatDefinition::new(
+    "zcr-test",
+    None,
+    "ZCR (testkit reference wire format)",
+    "zcr",
+    &["zcr"],
+    "image/x-zcr-test",
+    &["image/x-zcr-test"],
+    true,  // alpha
+    true,  // animation
+    true,  // lossless
+    false, // lossy
+    4,
+    detect_zcr,
+);
+
+static ZCR_FORMATS: &[ImageFormat] = &[ImageFormat::Custom(&ZCR_FORMAT)];
+
+/// The reference decoder re-registered under the custom `zcr-test` format.
+#[derive(Clone, Debug, Default)]
+struct ZcrDecoderConfig;
+
+impl DecoderConfig for ZcrDecoderConfig {
+    type Error = RefError;
+    type Job<'a> = <ReferenceDecoderConfig as DecoderConfig>::Job<'a>;
+
+    fn formats() -> &'static [ImageFormat] {
+        ZCR_FORMATS
+    }
+    fn supported_descriptors() -> &'static [PixelDescriptor] {
+        <ReferenceDecoderConfig as DecoderConfig>::supported_descriptors()
+    }
+    fn job<'a>(self) -> Self::Job<'a> {
+        ReferenceDecoderConfig.job()
+    }
+}
+
+// ===========================================================================
+// Helpers
+// ===========================================================================
+
+fn rgb_pixels(bytes: &[u8], width: u32, height: u32) -> PixelSlice<'_> {
+    PixelSlice::new(
+        bytes,
+        width,
+        height,
+        width as usize * 3,
+        PixelDescriptor::RGB8_SRGB,
+    )
+    .expect("valid pixel slice")
+}
+
+const W: u32 = 2;
+const H: u32 = 2;
+const PIXELS: [u8; 12] = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120];
+
+fn reference_set() -> CodecSet {
+    CodecSet::new()
+        .with_decoder(ReferenceDecoderConfig)
+        .with_encoder(ReferenceEncoderConfig::new())
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[test]
+fn encode_then_decode_as_roundtrips_pixels() {
+    let set = reference_set();
+
+    let encoded = set
+        .encode(ImageFormat::Pnm, rgb_pixels(&PIXELS, W, H))
+        .expect("encode");
+    assert_eq!(encoded.format(), ImageFormat::Pnm);
+
+    let decoded = set
+        .decode_as(ImageFormat::Pnm, encoded.data(), &[])
+        .expect("decode_as");
+    assert_eq!(decoded.width(), W);
+    assert_eq!(decoded.height(), H);
+    let out = decoded.pixels();
+    let mut round = Vec::new();
+    for y in 0..out.rows() {
+        round.extend_from_slice(out.row(y));
+    }
+    assert_eq!(round, PIXELS);
+}
+
+#[test]
+fn detect_consults_only_registered_formats() {
+    let set = reference_set();
+
+    // Real PNM magic → detected (reference registers under Pnm).
+    assert_eq!(set.detect(b"P6\n2 2\n255\n"), Some(ImageFormat::Pnm));
+    // JPEG magic is recognizable in general, but no JPEG decoder is registered.
+    assert_eq!(set.detect(&[0xFF, 0xD8, 0xFF, 0xE0]), None);
+
+    assert!(set.can_decode(ImageFormat::Pnm));
+    assert!(set.can_encode(ImageFormat::Pnm));
+    assert!(!set.can_decode(ImageFormat::Jpeg));
+    assert!(set.decoder_for(ImageFormat::Pnm).is_some());
+    assert!(set.encoder_for(ImageFormat::Pnm).is_some());
+}
+
+#[test]
+fn custom_format_detect_and_decode_end_to_end() {
+    // Encoder emits ZCR1 bytes; the Zcr wrapper's custom format detects them.
+    let set = CodecSet::new()
+        .with_decoder(ZcrDecoderConfig)
+        .with_encoder(ReferenceEncoderConfig::new());
+
+    let encoded = set
+        .encode(ImageFormat::Pnm, rgb_pixels(&PIXELS, W, H))
+        .expect("encode");
+
+    let detected = set.detect(encoded.data()).expect("detected");
+    assert_eq!(detected, ImageFormat::Custom(&ZCR_FORMAT));
+
+    // Full detect → decode path, no format named by the caller.
+    let decoded = set.decode(encoded.data()).expect("decode");
+    assert_eq!((decoded.width(), decoded.height()), (W, H));
+
+    // probe() goes through the same detection.
+    let info = set.probe(encoded.data()).expect("probe");
+    assert_eq!((info.width, info.height), (W, H));
+}
+
+#[test]
+fn shared_static_set_decodes_from_many_threads() {
+    static CODECS: LazyLock<CodecSet> = LazyLock::new(|| {
+        CodecSet::new()
+            .with_decoder(ZcrDecoderConfig)
+            .with_encoder(ReferenceEncoderConfig::new())
+            .with_limits(ResourceLimits::default())
+    });
+
+    let encoded = CODECS
+        .encode(ImageFormat::Pnm, rgb_pixels(&PIXELS, W, H))
+        .expect("encode");
+    let data = encoded.data().to_vec();
+
+    std::thread::scope(|scope| {
+        for _ in 0..4 {
+            let data = &data;
+            scope.spawn(move || {
+                let decoded = CODECS.decode(data).expect("decode on worker thread");
+                assert_eq!((decoded.width(), decoded.height()), (W, H));
+            });
+        }
+    });
+}
+
+#[test]
+fn encode_with_fidelity_clones_the_template() {
+    use zencodec::encode::Fidelity;
+
+    let set = reference_set();
+
+    // Per-call lossless override; the reference codec records it.
+    let out = set
+        .encode_with(
+            ImageFormat::Pnm,
+            Fidelity::Lossless,
+            rgb_pixels(&PIXELS, W, H),
+        )
+        .expect("encode_with");
+    let decoded = set
+        .decode_as(ImageFormat::Pnm, out.data(), &[])
+        .expect("decode");
+    assert_eq!((decoded.width(), decoded.height()), (W, H));
+
+    // The registered template is untouched — plain encode still works.
+    set.encode(ImageFormat::Pnm, rgb_pixels(&PIXELS, W, H))
+        .expect("template encode after encode_with");
+}
+
+#[test]
+fn encode_job_carries_metadata() {
+    let set = reference_set();
+
+    let meta = Metadata::none().with_icc(vec![1, 2, 3, 4]);
+    let mut job = set.encode_job(ImageFormat::Pnm).expect("encode_job");
+    job.set_metadata_policy(meta, MetadataPolicy::PreserveExact);
+    let encoder = job.into_encoder().expect("encoder");
+    let out = encoder.encode(rgb_pixels(&PIXELS, W, H)).expect("encode");
+
+    let decoded = set
+        .decode_as(ImageFormat::Pnm, out.data(), &[])
+        .expect("decode");
+    assert_eq!(
+        decoded.info().source_color.icc_profile.as_deref(),
+        Some(&[1u8, 2, 3, 4][..])
+    );
+}
+
+#[test]
+fn animation_roundtrip_through_set() {
+    let set = CodecSet::new()
+        .with_decoder(ZcrDecoderConfig)
+        .with_encoder(ReferenceEncoderConfig::new());
+
+    let frame_a = [255u8; 12];
+    let frame_b = [0u8; 12];
+
+    let mut job = set.encode_job(ImageFormat::Pnm).expect("encode_job");
+    job.set_loop_count(Some(0));
+    let mut enc = job
+        .into_animation_frame_encoder()
+        .expect("animation encoder");
+    enc.push_frame(rgb_pixels(&frame_a, W, H), 100, None)
+        .expect("frame a");
+    enc.push_frame(rgb_pixels(&frame_b, W, H), 200, None)
+        .expect("frame b");
+    let out = enc.finish(None).expect("finish");
+
+    let mut dec = set
+        .animation_decoder(out.data(), &[])
+        .expect("animation decoder");
+    assert_eq!(dec.frame_count(), Some(2));
+    let first = dec
+        .render_next_frame_owned(None)
+        .expect("render")
+        .expect("frame 0");
+    assert_eq!(first.duration_ms(), 100);
+    let second = dec
+        .render_next_frame_owned(None)
+        .expect("render")
+        .expect("frame 1");
+    assert_eq!(second.duration_ms(), 200);
+    assert!(dec.render_next_frame_owned(None).expect("render").is_none());
+}
+
+#[test]
+fn streaming_decoder_borrowing_the_set() {
+    let set = CodecSet::new()
+        .with_decoder(ZcrDecoderConfig)
+        .with_encoder(ReferenceEncoderConfig::new());
+
+    let encoded = set
+        .encode(ImageFormat::Pnm, rgb_pixels(&PIXELS, W, H))
+        .expect("encode");
+
+    let mut dec = set
+        .streaming_decoder(encoded.data(), &[])
+        .expect("streaming decoder");
+    let mut rows_seen = 0;
+    while let Some((y, strip)) = dec.next_batch().expect("batch") {
+        assert_eq!(y, rows_seen);
+        rows_seen += strip.rows();
+    }
+    assert_eq!(rows_seen, H);
+}
+
+#[test]
+fn missing_codecs_report_typed_errors() {
+    let set = CodecSet::new().with_decoder(ReferenceDecoderConfig);
+
+    match set.encode(ImageFormat::Pnm, rgb_pixels(&PIXELS, W, H)) {
+        Err(CodecSetError::NoEncoder(ImageFormat::Pnm)) => {}
+        other => panic!("expected NoEncoder(Pnm), got {other:?}"),
+    }
+    match set.decode_as(ImageFormat::Jpeg, b"\xFF\xD8\xFF", &[]) {
+        Err(CodecSetError::NoDecoder(ImageFormat::Jpeg)) => {}
+        other => panic!("expected NoDecoder(Jpeg), got {other:?}"),
+    }
+
+    // A codec failure passes through with the codec's error in the chain.
+    match set.decode_as(ImageFormat::Pnm, b"not zcr bytes at all", &[]) {
+        Err(CodecSetError::Codec(e)) => {
+            let msg = format!("{e}");
+            assert!(msg.contains("invalid"), "unexpected codec error: {msg}");
+        }
+        other => panic!("expected Codec error, got {other:?}"),
+    }
+}
+
+#[test]
+fn cloned_set_is_independent() {
+    let base = CodecSet::new().with_decoder(ReferenceDecoderConfig);
+    let extended = base.clone().with_encoder(ReferenceEncoderConfig::new());
+
+    assert!(!base.can_encode(ImageFormat::Pnm));
+    assert!(extended.can_encode(ImageFormat::Pnm));
+    assert!(extended.can_decode(ImageFormat::Pnm));
+}
+
+#[test]
+fn one_shot_trait_methods_work_directly() {
+    // The provided DecoderConfig::decode / probe and EncoderConfig::encode
+    // one-shots — no CodecSet, no job plumbing.
+    let out = ReferenceEncoderConfig::new()
+        .encode(rgb_pixels(&PIXELS, W, H))
+        .expect("one-shot encode");
+
+    let info = ReferenceDecoderConfig
+        .probe(out.data())
+        .expect("one-shot probe");
+    assert_eq!((info.width, info.height), (W, H));
+
+    let decoded = ReferenceDecoderConfig
+        .decode(out.data())
+        .expect("one-shot decode");
+    assert_eq!((decoded.width(), decoded.height()), (W, H));
+}

--- a/zencodec-testkit/tests/codec_set.rs
+++ b/zencodec-testkit/tests/codec_set.rs
@@ -2,66 +2,20 @@
 //!
 //! The reference codec registers under `ImageFormat::Pnm` but uses its own
 //! `ZCR1` wire format, so magic-byte *detection* tests either use real PNM
-//! magic (detection only — the bytes aren't decodable) or the `Zcr` wrapper
-//! below, which re-registers the reference decoder under a custom
-//! `ImageFormatDefinition` whose `detect` matches the actual wire format —
-//! exercising the full detect → decode path end to end.
+//! magic (detection only — the bytes aren't decodable) or
+//! `ReferenceZcrDecoderConfig` (from the testkit), which registers the decoder
+//! under a format whose `detect` matches the actual wire format — exercising
+//! the full detect → decode path end to end.
 
 use std::sync::LazyLock;
 
 use zencodec::estimate::{ComputeEnvironment, ImageCharacteristics};
 use zencodec::prelude::*;
-use zencodec::{
-    CodecSet, CodecSetError, ImageFormat, ImageFormatDefinition, Metadata, MetadataPolicy,
-    ResourceLimits,
+use zencodec::{CodecSet, CodecSetError, ImageFormat, Metadata, MetadataPolicy, ResourceLimits};
+use zencodec_testkit::{
+    ReferenceDecoderConfig, ReferenceEncoderConfig, ReferenceZcrDecoderConfig, ZCR_FORMAT,
 };
-use zencodec_testkit::{RefError, ReferenceDecoderConfig, ReferenceEncoderConfig};
 use zenpixels::{PixelDescriptor, PixelSlice};
-
-// ===========================================================================
-// A custom-format registration of the reference decoder
-// ===========================================================================
-
-fn detect_zcr(data: &[u8]) -> bool {
-    data.len() >= 4 && &data[..4] == b"ZCR1"
-}
-
-static ZCR_FORMAT: ImageFormatDefinition = ImageFormatDefinition::new(
-    "zcr-test",
-    None,
-    "ZCR (testkit reference wire format)",
-    "zcr",
-    &["zcr"],
-    "image/x-zcr-test",
-    &["image/x-zcr-test"],
-    true,  // alpha
-    true,  // animation
-    true,  // lossless
-    false, // lossy
-    4,
-    detect_zcr,
-);
-
-static ZCR_FORMATS: &[ImageFormat] = &[ImageFormat::Custom(&ZCR_FORMAT)];
-
-/// The reference decoder re-registered under the custom `zcr-test` format.
-#[derive(Clone, Debug, Default)]
-struct ZcrDecoderConfig;
-
-impl DecoderConfig for ZcrDecoderConfig {
-    type Error = RefError;
-    type Job<'a> = <ReferenceDecoderConfig as DecoderConfig>::Job<'a>;
-
-    fn formats() -> &'static [ImageFormat] {
-        ZCR_FORMATS
-    }
-    fn supported_descriptors() -> &'static [PixelDescriptor] {
-        <ReferenceDecoderConfig as DecoderConfig>::supported_descriptors()
-    }
-    fn job<'a>(self) -> Self::Job<'a> {
-        ReferenceDecoderConfig.job()
-    }
-}
 
 // ===========================================================================
 // Helpers
@@ -115,6 +69,42 @@ fn encode_then_decode_as_roundtrips_pixels() {
 }
 
 #[test]
+fn job_level_encode_matches_the_two_step_form() {
+    // The provided `EncodeJob::encode` / `DynEncodeJob::encode` one-shots must
+    // equal configuring the job then taking the encoder by hand — they are the
+    // common tail, folded into one call.
+
+    // Typed job: `.job().encode()` == `.job().encoder()?.encode()`.
+    let direct = ReferenceEncoderConfig::new()
+        .job()
+        .encode(rgb_pixels(&PIXELS, W, H))
+        .expect("typed job encode");
+    let two_step = ReferenceEncoderConfig::new()
+        .job()
+        .encoder()
+        .expect("encoder")
+        .encode(rgb_pixels(&PIXELS, W, H))
+        .expect("encode");
+    assert_eq!(direct.data(), two_step.data());
+
+    // Dyn job (what CodecSet hands back): `.encode()` == `.into_encoder()?.encode()`.
+    let set = reference_set();
+    let dyn_direct = set
+        .encode_job(ImageFormat::Pnm)
+        .expect("job")
+        .encode(rgb_pixels(&PIXELS, W, H))
+        .expect("dyn job encode");
+    let dyn_two_step = set
+        .encode_job(ImageFormat::Pnm)
+        .expect("job")
+        .into_encoder()
+        .expect("into_encoder")
+        .encode(rgb_pixels(&PIXELS, W, H))
+        .expect("encode");
+    assert_eq!(dyn_direct.data(), dyn_two_step.data());
+}
+
+#[test]
 fn detect_consults_only_registered_formats() {
     let set = reference_set();
 
@@ -134,7 +124,7 @@ fn detect_consults_only_registered_formats() {
 fn custom_format_detect_and_decode_end_to_end() {
     // Encoder emits ZCR1 bytes; the Zcr wrapper's custom format detects them.
     let set = CodecSet::new()
-        .with_decoder(ZcrDecoderConfig)
+        .with_decoder(ReferenceZcrDecoderConfig)
         .with_encoder(ReferenceEncoderConfig::new());
 
     let encoded = set
@@ -157,7 +147,7 @@ fn custom_format_detect_and_decode_end_to_end() {
 fn shared_static_set_decodes_from_many_threads() {
     static CODECS: LazyLock<CodecSet> = LazyLock::new(|| {
         CodecSet::new()
-            .with_decoder(ZcrDecoderConfig)
+            .with_decoder(ReferenceZcrDecoderConfig)
             .with_encoder(ReferenceEncoderConfig::new())
             .with_limits(ResourceLimits::default())
     });
@@ -224,7 +214,7 @@ fn encode_job_carries_metadata() {
 #[test]
 fn animation_roundtrip_through_set() {
     let set = CodecSet::new()
-        .with_decoder(ZcrDecoderConfig)
+        .with_decoder(ReferenceZcrDecoderConfig)
         .with_encoder(ReferenceEncoderConfig::new());
 
     let frame_a = [255u8; 12];
@@ -261,7 +251,7 @@ fn animation_roundtrip_through_set() {
 #[test]
 fn streaming_decoder_borrowing_the_set() {
     let set = CodecSet::new()
-        .with_decoder(ZcrDecoderConfig)
+        .with_decoder(ReferenceZcrDecoderConfig)
         .with_encoder(ReferenceEncoderConfig::new());
 
     let encoded = set
@@ -364,7 +354,7 @@ fn estimate_dispatches_to_the_registered_codec() {
 fn estimate_decode_of_probes_then_estimates() {
     // Zcr set so probe (detect + header parse) succeeds on the encoded bytes.
     let set = CodecSet::new()
-        .with_decoder(ZcrDecoderConfig)
+        .with_decoder(ReferenceZcrDecoderConfig)
         .with_encoder(ReferenceEncoderConfig::new());
     let compute = ComputeEnvironment::conservative();
 

--- a/zencodec-testkit/tests/codec_set.rs
+++ b/zencodec-testkit/tests/codec_set.rs
@@ -335,7 +335,7 @@ fn one_shot_trait_methods_work_directly() {
 fn estimate_dispatches_to_the_registered_codec() {
     let set = reference_set();
     let image = ImageCharacteristics::new(W, H, PixelDescriptor::RGB8_SRGB);
-    let compute = ComputeEnvironment::new();
+    let compute = ComputeEnvironment::conservative();
 
     // Registered format → forwards to the codec's estimator and succeeds
     // (even when the codec reports `unknown()`).
@@ -366,7 +366,7 @@ fn estimate_decode_of_probes_then_estimates() {
     let set = CodecSet::new()
         .with_decoder(ZcrDecoderConfig)
         .with_encoder(ReferenceEncoderConfig::new());
-    let compute = ComputeEnvironment::new();
+    let compute = ComputeEnvironment::conservative();
 
     let encoded = set
         .encode(ImageFormat::Pnm, rgb_pixels(&PIXELS, W, H))

--- a/zencodec-testkit/tests/usage.rs
+++ b/zencodec-testkit/tests/usage.rs
@@ -12,7 +12,7 @@ use std::sync::LazyLock;
 
 use zencodec::encode::Fidelity;
 use zencodec::estimate::ComputeEnvironment;
-use zencodec::{CodecSet, ImageFormat, Metadata, MetadataPolicy};
+use zencodec::{CodecSet, ColorEmitPolicy, ImageFormat, Metadata, MetadataPolicy};
 use zencodec_testkit::{ReferenceEncoderConfig, ReferenceZcrDecoderConfig};
 use zenpixels::{PixelDescriptor, PixelSlice};
 
@@ -69,6 +69,32 @@ fn share_one_set_app_wide() {
 
     let file = CODECS.encode(ImageFormat::Pnm, rgb8(&RGB)).unwrap();
     assert!(CODECS.probe(file.data()).is_ok());
+}
+
+// ── The one-call transcode ──────────────────────────────────────────────────
+
+#[test]
+fn transcode_in_one_call() {
+    let codecs = codecs();
+
+    // A source file (here the reference bytes stand in for, say, a JPEG).
+    let source = codecs.encode(ImageFormat::Pnm, rgb8(&RGB)).unwrap();
+
+    // decode → carry the source's metadata → re-encode, in one call — the
+    // headline proxy operation. `metadata` decides retention (`Web` strips
+    // GPS/camera/timestamps/XMP, keeps orientation + rights + color); `color`
+    // decides how color *signaling* is emitted (not a pixel CMS conversion).
+    let out = codecs
+        .transcode(
+            source.data(),
+            ImageFormat::Pnm,
+            Fidelity::Lossless,
+            MetadataPolicy::Web,
+            ColorEmitPolicy::Balanced,
+        )
+        .unwrap();
+
+    assert!(codecs.probe(out.data()).is_ok());
 }
 
 // ── Encode / decode controls ────────────────────────────────────────────────

--- a/zencodec-testkit/tests/usage.rs
+++ b/zencodec-testkit/tests/usage.rs
@@ -1,0 +1,263 @@
+//! Worked, runnable examples of the common ways to drive a [`zencodec::CodecSet`].
+//!
+//! Each `#[test]` is a self-contained example — read them top to bottom as a
+//! tutorial. The reference codec (accepts and produces RGB8 + RGBA8) stands in
+//! for a real codec.
+//!
+//! The last two examples show the extra reach a caller gets from
+//! `zenpixels-convert`: adapting a foreign pixel format into an encoder's
+//! supported set, and converting a decoded buffer into a caller-chosen format.
+
+use std::sync::LazyLock;
+
+use zencodec::encode::Fidelity;
+use zencodec::estimate::ComputeEnvironment;
+use zencodec::prelude::*;
+use zencodec::{CodecSet, ImageFormat, ImageFormatDefinition, Metadata, MetadataPolicy};
+use zencodec_testkit::{RefError, ReferenceDecoderConfig, ReferenceEncoderConfig};
+use zenpixels::{PixelDescriptor, PixelSlice};
+
+// ── Scaffolding ────────────────────────────────────────────────────────────
+// A real codec's format detects its own bytes. The reference encoder emits a
+// "ZCR1" wire format, so we register the decoder under a custom format whose
+// `detect` matches it — that's all it takes to make the detection-based APIs
+// (`decode`, `probe`, `estimate_decode_of`) work end to end below.
+
+fn detect_zcr(data: &[u8]) -> bool {
+    data.len() >= 4 && &data[..4] == b"ZCR1"
+}
+
+static ZCR: ImageFormatDefinition = ImageFormatDefinition::new(
+    "zcr",
+    None,
+    "ZCR (reference wire format)",
+    "zcr",
+    &["zcr"],
+    "image/x-zcr",
+    &["image/x-zcr"],
+    true,
+    true,
+    true,
+    false,
+    4,
+    detect_zcr,
+);
+static ZCR_FORMATS: &[ImageFormat] = &[ImageFormat::Custom(&ZCR)];
+
+#[derive(Clone, Debug, Default)]
+struct ZcrDecoderConfig;
+
+impl DecoderConfig for ZcrDecoderConfig {
+    type Error = RefError;
+    type Job<'a> = <ReferenceDecoderConfig as DecoderConfig>::Job<'a>;
+    fn formats() -> &'static [ImageFormat] {
+        ZCR_FORMATS
+    }
+    fn supported_descriptors() -> &'static [PixelDescriptor] {
+        <ReferenceDecoderConfig as DecoderConfig>::supported_descriptors()
+    }
+    fn job<'a>(self) -> Self::Job<'a> {
+        ReferenceDecoderConfig.job()
+    }
+}
+
+const W: u32 = 2;
+const H: u32 = 2;
+const RGB: [u8; 12] = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120];
+
+/// View tightly-packed RGB8 bytes as a [`PixelSlice`].
+fn rgb8(bytes: &[u8]) -> PixelSlice<'_> {
+    PixelSlice::new(bytes, W, H, W as usize * 3, PixelDescriptor::RGB8_SRGB).unwrap()
+}
+
+/// One codec set, built once. Real code registers real codecs here.
+fn codecs() -> CodecSet {
+    CodecSet::new()
+        .with_decoder(ZcrDecoderConfig)
+        .with_encoder(ReferenceEncoderConfig::new())
+}
+
+// ── The core round trip ─────────────────────────────────────────────────────
+
+#[test]
+fn encode_then_decode() {
+    let codecs = codecs();
+
+    // Encode: name the output format, hand it the pixels.
+    let file = codecs.encode(ImageFormat::Pnm, rgb8(&RGB)).unwrap();
+
+    // Decode: bytes in, pixels + info out. The format is auto-detected.
+    let image = codecs.decode(file.data()).unwrap();
+    assert_eq!((image.width(), image.height()), (W, H));
+}
+
+#[test]
+fn probe_without_decoding() {
+    let codecs = codecs();
+    let file = codecs.encode(ImageFormat::Pnm, rgb8(&RGB)).unwrap();
+
+    // Header parse only — no pixels touched.
+    let info = codecs.probe(file.data()).unwrap();
+    assert_eq!((info.width, info.height), (W, H));
+}
+
+#[test]
+fn share_one_set_app_wide() {
+    // `CodecSet` is Send + Sync + 'static and every op takes &self, so build it
+    // once behind a static and share it everywhere — no locking.
+    static CODECS: LazyLock<CodecSet> = LazyLock::new(codecs);
+
+    let file = CODECS.encode(ImageFormat::Pnm, rgb8(&RGB)).unwrap();
+    assert!(CODECS.probe(file.data()).is_ok());
+}
+
+// ── Encode / decode controls ────────────────────────────────────────────────
+
+#[test]
+fn encode_with_fidelity_and_metadata() {
+    let codecs = codecs();
+
+    // A per-call fidelity override, without disturbing the registered template.
+    let file = codecs
+        .encode_with(ImageFormat::Pnm, Fidelity::Lossless, rgb8(&RGB))
+        .unwrap();
+    assert!(codecs.probe(file.data()).is_ok());
+
+    // Metadata (ICC/EXIF/XMP) rides along via the escape-hatch job.
+    let mut job = codecs.encode_job(ImageFormat::Pnm).unwrap();
+    job.set_metadata_policy(
+        Metadata::none().with_icc(vec![1, 2, 3, 4]),
+        MetadataPolicy::PreserveExact,
+    );
+    let with_icc = job.into_encoder().unwrap().encode(rgb8(&RGB)).unwrap();
+    let info = codecs.probe(with_icc.data()).unwrap();
+    assert!(info.source_color.icc_profile.is_some());
+}
+
+#[test]
+fn decode_requesting_a_pixel_format() {
+    let codecs = codecs();
+    let file = codecs.encode(ImageFormat::Pnm, rgb8(&RGB)).unwrap();
+
+    // Ask the decoder to produce RGBA8. A decoder that can output several
+    // formats honors the preference; one that can't (like the reference)
+    // returns its native format — so read the descriptor back, don't assume it.
+    // When you truly need a format the decoder can't make, convert the output
+    // (see `convert_a_decoded_image_to_another_format`).
+    let image = codecs
+        .decode_preferring(file.data(), &[PixelDescriptor::RGBA8_SRGB])
+        .unwrap();
+    let _got = image.pixels().descriptor();
+    assert_eq!((image.width(), image.height()), (W, H));
+}
+
+#[test]
+fn stream_decode_by_strip() {
+    let codecs = codecs();
+    let file = codecs.encode(ImageFormat::Pnm, rgb8(&RGB)).unwrap();
+
+    // Pull strips instead of materializing the whole image.
+    let mut dec = codecs.streaming_decoder(file.data(), &[]).unwrap();
+    let mut rows = 0;
+    while let Some((_y, strip)) = dec.next_batch().unwrap() {
+        rows += strip.rows();
+    }
+    assert_eq!(rows, H);
+}
+
+// ── Estimate before you commit ──────────────────────────────────────────────
+
+#[test]
+fn estimate_before_encoding() {
+    let codecs = codecs();
+
+    // `estimate_encode_of` reads dims + format off the pixel slice you already
+    // hold — no `ImageCharacteristics` to build by hand. `host()` detects this
+    // machine (cores + SIMD tier; std only).
+    let est = codecs
+        .estimate_encode_of(ImageFormat::Pnm, rgb8(&RGB), &ComputeEnvironment::host())
+        .unwrap();
+
+    // The reference codec ships no cost model, so this is `unknown()`; a real
+    // codec fills in peak-memory / wall-time. The point is the one-call shape.
+    let _ = est;
+}
+
+#[test]
+fn estimate_before_decoding() {
+    let codecs = codecs();
+    let file = codecs.encode(ImageFormat::Pnm, rgb8(&RGB)).unwrap();
+
+    // `estimate_decode_of` probes the bytes for dims + format, then estimates.
+    // `conservative()` is the no_std-friendly single-core baseline.
+    let est = codecs
+        .estimate_decode_of(file.data(), &ComputeEnvironment::conservative())
+        .unwrap();
+    let _ = est;
+}
+
+// ── With zenpixels-convert on hand ──────────────────────────────────────────
+
+#[test]
+fn encode_from_a_foreign_pixel_format() {
+    use zenpixels_convert::adapt::adapt_for_encode;
+
+    let codecs = codecs();
+
+    // The caller holds a BGRA8 framebuffer — a format the encoder does NOT list.
+    // 2x2 BGRA: the RGB colors above, byte-swapped, opaque.
+    let bgra: [u8; 16] = [
+        30, 20, 10, 255, 60, 50, 40, 255, 90, 80, 70, 255, 120, 110, 100, 255,
+    ];
+
+    // What does this encoder accept? Ask the registry.
+    let supported = codecs
+        .encoder_for(ImageFormat::Pnm)
+        .unwrap()
+        .supported_descriptors();
+
+    // `adapt_for_encode` picks the best supported target and converts into it
+    // (it would borrow, zero-copy, if BGRA8 were already supported).
+    let adapted = adapt_for_encode(
+        &bgra,
+        PixelDescriptor::BGRA8_SRGB,
+        W,
+        H,
+        W as usize * 4,
+        supported,
+    )
+    .unwrap();
+
+    let bytes: &[u8] = &adapted.data;
+    let stride = adapted.width as usize * adapted.descriptor.bytes_per_pixel();
+    let slice = PixelSlice::new(
+        bytes,
+        adapted.width,
+        adapted.rows,
+        stride,
+        adapted.descriptor,
+    )
+    .unwrap();
+    let file = codecs.encode(ImageFormat::Pnm, slice).unwrap();
+
+    // Round-trips: decode back and red sits where RGB expects it.
+    let image = codecs.decode(file.data()).unwrap();
+    assert_eq!(image.pixels().row(0)[0], 10);
+}
+
+#[test]
+fn convert_a_decoded_image_to_another_format() {
+    use zenpixels_convert::PixelBufferConvertExt;
+
+    let codecs = codecs();
+    let file = codecs.encode(ImageFormat::Pnm, rgb8(&RGB)).unwrap();
+
+    // Decode gives the codec's native format; convert the owned buffer to
+    // whatever a downstream consumer wants (here BGRA8, e.g. for a GPU upload).
+    let image = codecs.decode(file.data()).unwrap();
+    let bgra = image
+        .into_buffer()
+        .convert_to(PixelDescriptor::BGRA8_SRGB)
+        .unwrap();
+    assert_eq!(bgra.as_slice().descriptor(), PixelDescriptor::BGRA8_SRGB);
+}

--- a/zencodec-testkit/tests/usage.rs
+++ b/zencodec-testkit/tests/usage.rs
@@ -12,54 +12,14 @@ use std::sync::LazyLock;
 
 use zencodec::encode::Fidelity;
 use zencodec::estimate::ComputeEnvironment;
-use zencodec::prelude::*;
-use zencodec::{CodecSet, ImageFormat, ImageFormatDefinition, Metadata, MetadataPolicy};
-use zencodec_testkit::{RefError, ReferenceDecoderConfig, ReferenceEncoderConfig};
+use zencodec::{CodecSet, ImageFormat, Metadata, MetadataPolicy};
+use zencodec_testkit::{ReferenceEncoderConfig, ReferenceZcrDecoderConfig};
 use zenpixels::{PixelDescriptor, PixelSlice};
 
-// ── Scaffolding ────────────────────────────────────────────────────────────
-// A real codec's format detects its own bytes. The reference encoder emits a
-// "ZCR1" wire format, so we register the decoder under a custom format whose
-// `detect` matches it — that's all it takes to make the detection-based APIs
-// (`decode`, `probe`, `estimate_decode_of`) work end to end below.
-
-fn detect_zcr(data: &[u8]) -> bool {
-    data.len() >= 4 && &data[..4] == b"ZCR1"
-}
-
-static ZCR: ImageFormatDefinition = ImageFormatDefinition::new(
-    "zcr",
-    None,
-    "ZCR (reference wire format)",
-    "zcr",
-    &["zcr"],
-    "image/x-zcr",
-    &["image/x-zcr"],
-    true,
-    true,
-    true,
-    false,
-    4,
-    detect_zcr,
-);
-static ZCR_FORMATS: &[ImageFormat] = &[ImageFormat::Custom(&ZCR)];
-
-#[derive(Clone, Debug, Default)]
-struct ZcrDecoderConfig;
-
-impl DecoderConfig for ZcrDecoderConfig {
-    type Error = RefError;
-    type Job<'a> = <ReferenceDecoderConfig as DecoderConfig>::Job<'a>;
-    fn formats() -> &'static [ImageFormat] {
-        ZCR_FORMATS
-    }
-    fn supported_descriptors() -> &'static [PixelDescriptor] {
-        <ReferenceDecoderConfig as DecoderConfig>::supported_descriptors()
-    }
-    fn job<'a>(self) -> Self::Job<'a> {
-        ReferenceDecoderConfig.job()
-    }
-}
+// The reference codec stands in for a real one. Its encoder emits a "ZCR1" wire
+// format; `ReferenceZcrDecoderConfig` registers the decoder under a format whose
+// `detect` matches those bytes, so the detection-based APIs (`decode`, `probe`,
+// `estimate_decode_of`) work end to end below with no custom-format boilerplate.
 
 const W: u32 = 2;
 const H: u32 = 2;
@@ -73,7 +33,7 @@ fn rgb8(bytes: &[u8]) -> PixelSlice<'_> {
 /// One codec set, built once. Real code registers real codecs here.
 fn codecs() -> CodecSet {
     CodecSet::new()
-        .with_decoder(ZcrDecoderConfig)
+        .with_decoder(ReferenceZcrDecoderConfig)
         .with_encoder(ReferenceEncoderConfig::new())
 }
 
@@ -123,13 +83,14 @@ fn encode_with_fidelity_and_metadata() {
         .unwrap();
     assert!(codecs.probe(file.data()).is_ok());
 
-    // Metadata (ICC/EXIF/XMP) rides along via the escape-hatch job.
+    // Metadata (ICC/EXIF/XMP) rides along via the job. Configure it, then
+    // `encode` straight off the job — no `into_encoder()` step.
     let mut job = codecs.encode_job(ImageFormat::Pnm).unwrap();
     job.set_metadata_policy(
         Metadata::none().with_icc(vec![1, 2, 3, 4]),
         MetadataPolicy::PreserveExact,
     );
-    let with_icc = job.into_encoder().unwrap().encode(rgb8(&RGB)).unwrap();
+    let with_icc = job.encode(rgb8(&RGB)).unwrap();
     let info = codecs.probe(with_icc.data()).unwrap();
     assert!(info.source_color.icc_profile.is_some());
 }


### PR DESCRIPTION
## What

Makes zencodec implementors trivially usable on their own and in groups, per the "registry easy, implementors super easy" design discussion:

1. **`CodecSet`** (`src/set.rs`, re-exported at the root) — a multi-codec registry over the existing object-safe `DynDecoderConfig` / `DynEncoderConfig` traits. Register configs one line each; the set gives you `detect` → `decode`, `probe`, `push_decode`, `animation_decoder`, `streaming_decoder`, and format-keyed `encode` / `encode_with(Fidelity)`, plus `decode_job` / `encode_job` escape hatches with the set's `ResourceLimits` / `StopToken` / policies pre-stamped.
2. **One-shot provided methods** on the config traits — `DecoderConfig::decode(data)`, `DecoderConfig::probe(data)`, `EncoderConfig::encode(pixels)` — single-line config→result use with default job settings. Default bodies; no codec crate changes needed.
3. **`zencodec::prelude`** — one-import bundle of every encode/decode trait (generic + dyn).

## Shareable app-wide (statically)

`CodecSet` is `Send + Sync + 'static`, every operation takes `&self`, and it's `Clone` (base set → per-tenant variants). The intended pattern, exercised by a dedicated test that decodes from 4 threads through a `static LazyLock<CodecSet>`:

```rust
static CODECS: LazyLock<CodecSet> = LazyLock::new(|| CodecSet::new()
    .with_decoder(zenjpeg::JpegDecoderConfig::new())
    .with_encoder(zenjpeg::JpegEncoderConfig::new().with_generic_quality(85.0)));

let image = CODECS.decode(&bytes)?;
```

## Design notes

- **No new required methods on the public `Dyn*` traits.** Clone/fidelity capability is captured at registration via private entry supertraits (`DecoderEntry` / `EncoderEntry`), so manual implementors of `DynDecoderConfig` / `DynEncoderConfig` are unaffected — `cargo semver-checks`: 196 pass, valid minor.
- **Detection can't be mis-ordered.** `detect()` walks `ImageFormatRegistry::common()`'s curated priority (AVIF-before-HEIC, DNG-before-TIFF) filtered to registered decoders, then `Custom` formats in registration order.
- **Encoder configs are templates.** Codec-specific options are set on the concrete type before registration; `encode_with` clones the template and applies a per-call `Fidelity`.
- Codec failures pass through as `CodecSetError::Codec` with the codec's error chain intact (`source()` / `find_cause`).

## Testing

- 6 codec-free unit tests in `set.rs` (Send+Sync+'static assertion, empty-set behavior, typed errors, Clone/Debug).
- 11 behavior tests in `zencodec-testkit/tests/codec_set.rs` against the reference codec: roundtrip, registration-scoped detection, custom-format detect→decode end to end, static `LazyLock` multi-thread sharing, template cloning, metadata via `encode_job`, animation + streaming through the set, typed errors, one-shot trait methods.
- Full workspace: 743 tests pass, 0 failed. `cargo fmt --check`, `clippy --workspace --all-targets` clean, apidoc snapshot regenerated + `ZEN_API_DOC=check` green, `cargo semver-checks check-release` green (0.1.26 → 0.1.27 minor).

Version bumped to 0.1.27 in-tree because 0.1.26 is already published and CI's semver gate enforces version adequacy for the additive API. Publishing remains a separate, user-approved step.

Noticed while editing (not changed here): `docs/spec.md` mentions `ImageFormat::from_magic()`, which doesn't exist in source (detection is `ImageFormatRegistry::detect()`); the repo CLAUDE.md "No CodecError here" line is similarly stale. Happy to batch those corrections separately.
